### PR TITLE
Reorganize and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/SequentialGuid.svg)](https://www.nuget.org/packages/SequentialGuid/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/buvinghausen/SequentialGuid/blob/master/LICENSE.txt)
 
-A dependency-free library for generating [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562.html) compliant UUIDs in .NET. All five structs — `GuidV4`, `GuidV5`, `GuidV7`, `GuidV8Time`, and `GuidV8Name` — conform to the RFC 9562 specification with correct version nibble and variant bits. Time-based UUIDs embed the creation timestamp into the value, which typically results in lower clustered index fragmentation when used as database primary keys. You can generate IDs all the way up in WebAssembly or MAUI, pass them through your API, and store them in the database — helping with idempotency without requiring a trip to the database to generate the key.
+A dependency-free library for generating [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562.html) compliant UUIDs in .NET. All five classes — `GuidV4`, `GuidV5`, `GuidV7`, `GuidV8Time`, and `GuidV8Name` — conform to the RFC 9562 specification with correct version nibble and variant bits. Time-based UUIDs embed the creation timestamp into the value, which typically results in lower clustered index fragmentation when used as database primary keys. You can generate IDs all the way up in WebAssembly or MAUI, pass them through your API, and store them in the database — helping with idempotency without requiring a trip to the database to generate the key.
 
 ## UUID Versions at a Glance
 

--- a/README.md
+++ b/README.md
@@ -6,38 +6,70 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/SequentialGuid.svg)](https://www.nuget.org/packages/SequentialGuid/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/buvinghausen/SequentialGuid/blob/master/LICENSE.txt)
 
-A dependency-free library for generating [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562.html) compliant UUIDs in .NET. All five classes — `GuidV4`, `GuidV5`, `GuidV7`, `GuidV8Time`, and `GuidV8Name` — conform to the RFC 9562 specification with correct version nibble and variant bits. Time-based UUIDs embed the creation timestamp into the value, which typically results in lower clustered index fragmentation when used as database primary keys. You can generate IDs all the way up in WebAssembly or MAUI, pass them through your API, and store them in the database — helping with idempotency without requiring a trip to the database to generate the key.
+**Generate database-friendly, time-ordered UUIDs anywhere in your stack — no database round-trip required.**
+
+SequentialGuid is a zero-dependency .NET library that produces [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562.html) compliant UUIDs. Generate IDs in Blazor WebAssembly, MAUI, a background worker, or a REST controller — then pass them through your API and into the database. Because the timestamp is embedded in the value itself, you get **natural sort order** (dramatically reducing clustered index fragmentation), **built-in timestamp extraction** (no extra `CreatedAt` column needed), and **client-side idempotency** (retry-safe inserts without a server round-trip to generate a key).
+
+### Why not just use `Guid.NewGuid()`?
+
+`Guid.NewGuid()` produces random version 4 UUIDs. They work, but they **fragment clustered indexes** in SQL Server, PostgreSQL, and other B-tree based stores because every insert lands at a random page. SequentialGuid solves this by putting the timestamp first — new rows always append near the end of the index, just like an auto-increment integer, while still giving you the global uniqueness and merge-safety of a UUID.
 
 ## UUID Versions at a Glance
 
-| Struct | RFC 9562 Section | Purpose |
+| Class | RFC 9562 Section | Purpose |
 |---|---|---|
-| `GuidV4` | §5.4 | Cryptographically random UUID — drop-in replacement for `Guid.NewGuid()` with guaranteed RFC 9562 version/variant bits |
+| `GuidV4` | §5.4 | Cryptographically random UUID — drop-in replacement for `Guid.NewGuid()` with guaranteed RFC 9562 version & variant bits |
 | `GuidV5` | §5.5 | Deterministic, namespace + name UUID using **SHA-1** hashing |
-| `GuidV7` | §5.7 | Time-ordered UUID using a **48-bit Unix millisecond** timestamp with a monotonic counter (RFC 9562 §6.2 Method 1) |
-| `GuidV8Time` | Appendix B.1 | Time-ordered UUID using **60-bit .NET Ticks** for sub-millisecond precision, plus a machine/process identifier and counter |
+| `GuidV7` | §5.7 | Time-ordered UUID — **48-bit Unix millisecond** timestamp + **26-bit monotonic counter** ([§6.2 Method 1](https://www.rfc-editor.org/rfc/rfc9562.html#section-6.2)) + 36 bits of cryptographic randomness |
+| `GuidV8Time` | Appendix B.1 | Time-ordered UUID — **60-bit .NET Ticks** (100 ns precision) + machine/process fingerprint + 22-bit monotonic counter |
 | `GuidV8Name` | Appendix B.2 | Deterministic, namespace + name UUID using **SHA-256** hashing |
+
+## Highlights
+
+- **RFC 9562 compliant** — correct version nibble and variant bits on every UUID, every time
+- **Monotonically increasing** — `GuidV7` and `GuidV8Time` both use a process-global `Interlocked.Increment` counter so IDs generated on the same timestamp are still strictly ordered, even under heavy concurrency
+- **Zero dependencies** — the core package references nothing outside the BCL
+- **Zero allocations on modern .NET** — `stackalloc`, `Span<T>`, and `[SkipLocalsInit]` eliminate heap allocations on the hot path (.NET 8+)
+- **Broad platform support** — targets **.NET 10 / 9 / 8**, **.NET Framework 4.6.2**, and **.NET Standard 2.0**, with explicit `browser` platform support for Blazor WebAssembly
+- **Round-trip timestamp extraction** — call `.ToDateTime()` on any `Guid` (V7, V8, or legacy) to recover the embedded UTC timestamp — works on `SqlGuid` too
+- **SQL Server sort-order aware** — `NewSqlGuid()` and `.ToSqlGuid()` / `.ToGuid()` handle the byte-order shuffle so your UUIDs sort chronologically in `uniqueidentifier` columns
+- **Built-in benchmarks** — a BenchmarkDotNet project is included so you can measure generation and conversion performance on your own hardware
 
 ### GuidV7 vs GuidV8Time — Which Should I Use?
 
-Both generate time-ordered, sortable UUIDs. The key difference is **timestamp precision**:
+Both generate time-ordered, sortable UUIDs. The difference is **timestamp resolution** and **payload**:
 
-* **`GuidV7`** — Uses a standard 48-bit Unix Epoch **millisecond** timestamp as defined by RFC 9562 §5.7. This is the most interoperable choice and is recommended if you are exchanging UUIDs with non-.NET systems or millisecond precision is sufficient.
-* **`GuidV8Time`** — Uses 60 bits of .NET `DateTime.Ticks` (100-nanosecond intervals) for **sub-millisecond precision**. Use this when you need/want precision beyond the millisecond level or want to retain the machine/process identifier from the original algorithm.
+| | `GuidV7` | `GuidV8Time` |
+|---|---|---|
+| Timestamp precision | **1 ms** (Unix Epoch millis) | **100 ns** (.NET Ticks) |
+| Counter bits | 26-bit monotonic | 22-bit monotonic |
+| Random / identity bits | 36 bits of crypto-random data | 40-bit machine + process fingerprint |
+| Interoperability | ✅ Standard UUIDv7 — understood by any RFC 9562 implementation | .NET-specific custom layout |
+| Best for | Cross-platform / polyglot systems, general-purpose use | .NET-only systems that need sub-millisecond ordering or machine traceability |
+
+**Rule of thumb:** Start with `GuidV7`. Reach for `GuidV8Time` only when you need tick-level precision or the machine/process fingerprint.
 
 ### GuidV5 vs GuidV8Name
 
 Both produce deterministic UUIDs from a namespace + name pair. The **only** difference is the hash algorithm:
 
-* **`GuidV5`** — Uses **SHA-1** as required by RFC 9562 §5.5.
-* **`GuidV8Name`** — Uses **SHA-256** as described in RFC 9562 Appendix B.2, providing a stronger hash at the cost of not being interoperable with standard UUIDv5 implementations in other languages.
+* **`GuidV5`** — Uses **SHA-1** as required by RFC 9562 §5.5. Choose this when you need interoperability with UUIDv5 implementations in other languages.
+* **`GuidV8Name`** — Uses **SHA-256** as described in RFC 9562 Appendix B.2, providing a stronger hash for .NET-only scenarios.
 
 ## Quick Start
+
+### Install
+
+```shell
+dotnet add package SequentialGuid
+```
 
 ### Generate a time-ordered UUID
 
 ```csharp
-// Millisecond precision (RFC 9562 UUIDv7)
+using SequentialGuid;
+
+// Millisecond precision (RFC 9562 UUIDv7) — recommended for most applications
 var id = GuidV7.NewGuid();
 
 // Sub-millisecond / tick precision (RFC 9562 UUIDv8)
@@ -57,34 +89,40 @@ var sqlId = GuidV8Time.NewSqlGuid();
 ### Generate a random UUID (V4)
 
 ```csharp
+// Guaranteed RFC 9562 version & variant bits (unlike Guid.NewGuid() on some runtimes)
 var id = GuidV4.NewGuid();
 ```
 
 ### Generate a deterministic UUID from a namespace + name
 
 ```csharp
-// SHA-1 (UUIDv5)
+// SHA-1 (UUIDv5) — interoperable with other languages
 var id = GuidV5.Create(GuidV5.Namespaces.Url, "https://example.com");
 
-// SHA-256 (UUIDv8 name-based)
+// SHA-256 (UUIDv8 name-based) — stronger hash, .NET only
 var id = GuidV8Name.Create(GuidV8Name.Namespaces.Url, "https://example.com");
 ```
 
 ### Extract the timestamp from any time-based UUID
 
 ```csharp
-DateTime? timestamp = id.ToDateTime();
+DateTime? created = id.ToDateTime();
+// Works on GuidV7, GuidV8Time, legacy SequentialGuid, and even SqlGuid values
 ```
 
 ### Convert between Guid and SqlGuid
 
 ```csharp
 var guid = GuidV7.NewGuid();
-var sqlGuid = guid.ToSqlGuid();
+var sqlGuid = guid.ToSqlGuid();  // reorder bytes for SQL Server
+var back = sqlGuid.ToGuid();     // restore standard byte order
 ```
+
+### Stamp a timestamp from an existing DateTime / DateTimeOffset
+
 ```csharp
-var sqlGuid = GuidV7.NewSqlGuid();
-var guid = sqlGuid.ToGuid();
+var id = GuidV7.NewGuid(DateTimeOffset.UtcNow);
+var id = GuidV8Time.NewGuid(DateTime.UtcNow);
 ```
 
 ### Dependency injection example
@@ -109,28 +147,38 @@ services.AddTransient<IIdGenerator, SequentialIdGenerator>();
 ```csharp
 public abstract class BaseEntity
 {
+    // ID is assigned at construction — no database round-trip needed
     public Guid Id { get; set; } = GuidV7.NewGuid();
-    public DateTime? Timestamp => Id.ToDateTime();
-    // If you really must have non-UTC time
-    public DateTime? LocalTime => Id.ToDateTime()?.ToLocalTime();
+
+    // Timestamp is always available — no extra column required
+    public DateTime? CreatedAt => Id.ToDateTime();
 }
 ```
 
 ## SQL Server Sorting
 
-If you use [SQL Server](https://www.microsoft.com/en-us/sql-server/) I highly recommend reading the following two articles to understand how SQL Server sorts [uniqueidentifier](https://learn.microsoft.com/en-us/sql/t-sql/data-types/uniqueidentifier-transact-sql) values:
+SQL Server sorts `uniqueidentifier` values in a [non-obvious byte order](https://www.sqlbi.com/blog/alberto/2007/08/31/how-are-guids-sorted-by-sql-server/). If you use SQL Server, read these two articles to understand the implications:
 
 * [Comparing GUID and uniqueidentifier Values](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql/comparing-guid-and-uniqueidentifier-values)
 * [How are GUIDs sorted by SQL Server?](https://www.sqlbi.com/blog/alberto/2007/08/31/how-are-guids-sorted-by-sql-server/)
 
-Use the `NewSqlGuid()` methods (or the `.ToSqlGuid()` extension) to produce UUIDs whose byte order aligns with SQL Server's comparison logic.
+Use the `NewSqlGuid()` methods (or the `.ToSqlGuid()` extension) to produce UUIDs whose byte order aligns with SQL Server's comparison logic. The `.ToGuid()` extension on `SqlGuid` reverses the transformation.
 
 ## Companion Packages
 
 | Package | Purpose |
 |---|---|
-| **SequentialGuid.NodaTime** | Extension methods for `Instant` and other NodaTime types |
-| **SequentialGuid.MongoDB** | `IIdGenerator` integration for the MongoDB C# driver |
+| [**SequentialGuid.NodaTime**](https://www.nuget.org/packages/SequentialGuid.NodaTime/) | Extension methods for `Instant`, `OffsetDateTime`, and `ZonedDateTime` — generate and extract timestamps using NodaTime types |
+| [**SequentialGuid.MongoDB**](https://www.nuget.org/packages/SequentialGuid.MongoDB/) | Drop-in `IIdGenerator` for the MongoDB C# driver — register once and every inserted document gets a sequential `Guid` ID |
+
+## Performance
+
+On modern .NET the hot paths are **zero-allocation** — byte buffers use `stackalloc` and `Span<T>`, and conversion methods are annotated with `[SkipLocalsInit]`. A BenchmarkDotNet project is included under `util/Benchmarks` so you can verify on your own hardware:
+
+```shell
+cd util/Benchmarks
+dotnet run -c Release -- --filter *Generation*
+```
 
 ## Upgrade Guide
 

--- a/src/SequentialGuid/ByteArrayExtensions.cs
+++ b/src/SequentialGuid/ByteArrayExtensions.cs
@@ -5,6 +5,8 @@ internal static class ByteArrayExtensions
 	extension(byte[] b)
 	{
 #if !NET6_0_OR_GREATER
+		// Defined are the legacy functions needed to provide support
+
 		// Swaps between .NET mixed-endian and RFC 9562 network (big-endian) byte order.
 		// Reverses Data1 (4 bytes), Data2 (2 bytes), and Data3 (2 bytes); Data4 is unchanged.
 		// This mapping is self-inverse: applying it twice returns the original bytes.
@@ -52,7 +54,7 @@ internal static class ByteArrayExtensions
 			b.IsRfc9562Version(7) ? b.Rfc9562V7UnixMs().Rfc9562V7Ticks :
 			b.IsLegacy() ? b.LegacyTicks :
 			null;
-#endif
+
 		// The big endian lead byte was always 8 in the legacy calculation
 		internal bool IsLegacy() =>
 			b[3] == 8 && !b.VariantIsRfc9562();
@@ -61,6 +63,12 @@ internal static class ByteArrayExtensions
 		internal bool VariantIsRfc9562() =>
 			(b[8] & 0xC0) == 0x80;
 
+		// version is in the high nibble of bytes[7] (Data3 high byte, little-endian)
+		internal bool IsRfc9562Version(byte version) =>
+			b[7] >> 4 == version && b.VariantIsRfc9562();
+#endif
+		// There is no need to span these functions
+
 		// Sets the RFC 9562 version nibble (bits 48-51) in bytes[6]
 		internal void SetRfc9562Version(byte version) =>
 			b[6] = (byte)((b[6] & 0x0F) | (version << 4));
@@ -68,13 +76,10 @@ internal static class ByteArrayExtensions
 		// Sets the RFC 9562 variant bits (10xxxxxx) on bytes[8]
 		internal void SetRfc9562Variant() =>
 			b[8] = (byte)((b[8] & 0x3F) | 0x80);
-
-		// version is in the high nibble of bytes[7] (Data3 high byte, little-endian)
-		internal bool IsRfc9562Version(byte version) =>
-			b[7] >> 4 == version && b.VariantIsRfc9562();
 	}
 
 #if NET6_0_OR_GREATER
+	// Here are the span related functions for modern .NET
 	extension(ReadOnlySpan<byte> b)
 	{
 		internal bool VariantIsRfc9562() =>

--- a/src/SequentialGuid/ByteArrayExtensions.cs
+++ b/src/SequentialGuid/ByteArrayExtensions.cs
@@ -13,7 +13,15 @@ internal static class ByteArrayExtensions
 
 		internal byte[] FromSqlByteOrder() =>
 			[b[13], b[12], b[11], b[10], b[15], b[14], b[9], b[8], b[6], b[7], b[4], b[5], b[0], b[1], b[2], b[3]];
-		
+
+		internal long Rfc9562V7UnixMs =>
+			((long)b[3] << 40) |
+			((long)b[2] << 32) |
+			((long)b[1] << 24) |
+			((long)b[0] << 16) |
+			((long)b[5] << 8) |
+			b[4];
+
 		private long Rfc9562V8Ticks =>
 			((long)b[3] << 52) +
 			((long)b[2] << 44) +
@@ -45,6 +53,10 @@ internal static class ByteArrayExtensions
 		internal byte[] ToSqlByteOrder() =>
 			[b[12], b[13], b[14], b[15], b[10], b[11], b[8], b[9], b[7], b[6], b[3], b[2], b[1], b[0], b[5], b[4]];
 
+		// The big endian lead byte was always 8 in the legacy calculation
+		internal bool IsLegacy() =>
+			b[3] == 8 && !b.VariantIsRfc9562();
+
 		// RFC 9562 variant: bits 7-6 of bytes[8] (Data4[0]) must be 10
 		internal bool VariantIsRfc9562() =>
 			(b[8] & 0xC0) == 0x80;
@@ -57,30 +69,9 @@ internal static class ByteArrayExtensions
 		internal void SetRfc9562Variant() =>
 			b[8] = (byte)((b[8] & 0x3F) | 0x80);
 
-		// For SQL byte order the variant is the 7th byte
-		internal bool SqlVariantIsRfc9562() =>
-			(b[6] & 0xC0) == 0x80;
-
-		// The big endian lead byte was always 8 in the legacy calculation
-		internal bool IsLegacy() =>
-			b[3] == 8 && !b.VariantIsRfc9562();
-
-		// In sql byte order the 11th byte was always 8
-		internal bool IsSqlLegacy() =>
-			b[10] == 8 && !b.SqlVariantIsRfc9562();
-
 		// version is in the high nibble of bytes[7] (Data3 high byte, little-endian)
 		internal bool IsRfc9562Version(byte version) =>
 			b[7] >> 4 == version && b.VariantIsRfc9562();
-
-		internal long Rfc9562V7UnixMs =>
-			((long)b[3] << 40) |
-			((long)b[2] << 32) |
-			((long)b[1] << 24) |
-			((long)b[0] << 16) |
-			((long)b[5] << 8) |
-			b[4];
-
 	}
 
 #if NET6_0_OR_GREATER

--- a/src/SequentialGuid/ByteArrayExtensions.cs
+++ b/src/SequentialGuid/ByteArrayExtensions.cs
@@ -11,10 +11,15 @@ internal static class ByteArrayExtensions
 		internal byte[] SwapByteOrder() =>
 			[b[3], b[2], b[1], b[0], b[5], b[4], b[7], b[6], b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]];
 
+		//See: https://www.sqlbi.com/blog/alberto/2007/08/31/how-are-guids-sorted-by-sql-server/
+		//See: https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql/comparing-guid-and-uniqueidentifier-values
+		internal byte[] ToSqlByteOrder() =>
+			[b[12], b[13], b[14], b[15], b[10], b[11], b[8], b[9], b[7], b[6], b[3], b[2], b[1], b[0], b[5], b[4]];
+
 		internal byte[] FromSqlByteOrder() =>
 			[b[13], b[12], b[11], b[10], b[15], b[14], b[9], b[8], b[6], b[7], b[4], b[5], b[0], b[1], b[2], b[3]];
 
-		internal long Rfc9562V7UnixMs =>
+		internal long Rfc9562V7UnixMs() =>
 			((long)b[3] << 40) |
 			((long)b[2] << 32) |
 			((long)b[1] << 24) |
@@ -44,15 +49,10 @@ internal static class ByteArrayExtensions
 
 		internal long? ToTicks() =>
 			b.IsRfc9562Version(8) ? b.Rfc9562V8Ticks :
-			b.IsRfc9562Version(7) ? b.Rfc9562V7UnixMs.Rfc9562V7Ticks :
+			b.IsRfc9562Version(7) ? b.Rfc9562V7UnixMs().Rfc9562V7Ticks :
 			b.IsLegacy() ? b.LegacyTicks :
 			null;
 #endif
-		//See: https://www.sqlbi.com/blog/alberto/2007/08/31/how-are-guids-sorted-by-sql-server/
-		//See: https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql/comparing-guid-and-uniqueidentifier-values
-		internal byte[] ToSqlByteOrder() =>
-			[b[12], b[13], b[14], b[15], b[10], b[11], b[8], b[9], b[7], b[6], b[3], b[2], b[1], b[0], b[5], b[4]];
-
 		// The big endian lead byte was always 8 in the legacy calculation
 		internal bool IsLegacy() =>
 			b[3] == 8 && !b.VariantIsRfc9562();
@@ -86,7 +86,7 @@ internal static class ByteArrayExtensions
 		internal bool IsRfc9562Version(byte version) =>
 			b[7] >> 4 == version && b.VariantIsRfc9562();
 
-		internal long Rfc9562V7UnixMs =>
+		internal long Rfc9562V7UnixMs() =>
 			((long)b[3] << 40) |
 			((long)b[2] << 32) |
 			((long)b[1] << 24) |
@@ -116,7 +116,7 @@ internal static class ByteArrayExtensions
 
 		internal long? ToTicks() =>
 			b.IsRfc9562Version(8) ? b.Rfc9562V8Ticks :
-			b.IsRfc9562Version(7) ? b.Rfc9562V7UnixMs.Rfc9562V7Ticks :
+			b.IsRfc9562Version(7) ? b.Rfc9562V7UnixMs().Rfc9562V7Ticks :
 			b.IsLegacy() ? b.LegacyTicks :
 			null;
 

--- a/src/SequentialGuid/ByteArrayExtensions.cs
+++ b/src/SequentialGuid/ByteArrayExtensions.cs
@@ -4,20 +4,46 @@ internal static class ByteArrayExtensions
 {
 	extension(byte[] b)
 	{
-#if NETFRAMEWORK || NETSTANDARD
+#if !NET6_0_OR_GREATER
 		// Swaps between .NET mixed-endian and RFC 9562 network (big-endian) byte order.
 		// Reverses Data1 (4 bytes), Data2 (2 bytes), and Data3 (2 bytes); Data4 is unchanged.
 		// This mapping is self-inverse: applying it twice returns the original bytes.
 		internal byte[] SwapByteOrder() =>
 			[b[3], b[2], b[1], b[0], b[5], b[4], b[7], b[6], b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]];
+
+		internal byte[] FromSqlByteOrder() =>
+			[b[13], b[12], b[11], b[10], b[15], b[14], b[9], b[8], b[6], b[7], b[4], b[5], b[0], b[1], b[2], b[3]];
+		
+		private long Rfc9562V8Ticks =>
+			((long)b[3] << 52) +
+			((long)b[2] << 44) +
+			((long)b[1] << 36) +
+			((long)b[0] << 28) +
+			((long)b[5] << 20) +
+			((long)b[4] << 12) +
+			(((long)b[7] & 0x0F) << 8) +
+			b[6];
+
+		private long LegacyTicks =>
+			((long)b[3] << 56) +
+			((long)b[2] << 48) +
+			((long)b[1] << 40) +
+			((long)b[0] << 32) +
+			((long)b[5] << 24) +
+			(b[4] << 16) +
+			(b[7] << 8) +
+			b[6];
+
+		internal long? ToTicks() =>
+			b.IsRfc9562Version(8) ? b.Rfc9562V8Ticks :
+			b.IsRfc9562Version(7) ? b.Rfc9562V7UnixMs.Rfc9562V7Ticks :
+			b.IsLegacy() ? b.LegacyTicks :
+			null;
 #endif
 		//See: https://www.sqlbi.com/blog/alberto/2007/08/31/how-are-guids-sorted-by-sql-server/
 		//See: https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql/comparing-guid-and-uniqueidentifier-values
 		internal byte[] ToSqlByteOrder() =>
 			[b[12], b[13], b[14], b[15], b[10], b[11], b[8], b[9], b[7], b[6], b[3], b[2], b[1], b[0], b[5], b[4]];
-
-		internal byte[] FromSqlByteOrder() =>
-			[b[13], b[12], b[11], b[10], b[15], b[14], b[9], b[8], b[6], b[7], b[4], b[5], b[0], b[1], b[2], b[3]];
 
 		// RFC 9562 variant: bits 7-6 of bytes[8] (Data4[0]) must be 10
 		internal bool VariantIsRfc9562() =>
@@ -55,34 +81,9 @@ internal static class ByteArrayExtensions
 			((long)b[5] << 8) |
 			b[4];
 
-		private long Rfc9562V8Ticks =>
-			((long)b[3] << 52) +
-			((long)b[2] << 44) +
-			((long)b[1] << 36) +
-			((long)b[0] << 28) +
-			((long)b[5] << 20) +
-			((long)b[4] << 12) +
-			(((long)b[7] & 0x0F) << 8) +
-			b[6];
-
-		private long LegacyTicks =>
-			((long)b[3] << 56) +
-			((long)b[2] << 48) +
-			((long)b[1] << 40) +
-			((long)b[0] << 32) +
-			((long)b[5] << 24) +
-			(b[4] << 16) +
-			(b[7] << 8) +
-			b[6];
-
-		internal long? ToTicks() =>
-			b.IsRfc9562Version(8) ? b.Rfc9562V8Ticks :
-			b.IsRfc9562Version(7) ? b.Rfc9562V7UnixMs.Rfc9562V7Ticks :
-			b.IsLegacy() ? b.LegacyTicks :
-			null;
 	}
 
-#if !NETFRAMEWORK && !NETSTANDARD
+#if NET6_0_OR_GREATER
 	extension(ReadOnlySpan<byte> b)
 	{
 		internal bool VariantIsRfc9562() =>

--- a/src/SequentialGuid/GuidExtensions.cs
+++ b/src/SequentialGuid/GuidExtensions.cs
@@ -25,10 +25,10 @@ public static class GuidExtensions
 		/// </returns>
 		public DateTime? ToDateTime()
 		{
-#if !NETFRAMEWORK && !NETSTANDARD
+#if NET6_0_OR_GREATER
 			Span<byte> bytes = stackalloc byte[16];
 			id.TryWriteBytes(bytes);
-			var ticks = (bytes).ToTicks();
+			var ticks = bytes.ToTicks();
 #else
 			var bytes = id.ToByteArray();
 			var ticks = bytes.ToTicks();
@@ -36,10 +36,10 @@ public static class GuidExtensions
 			if (ticks is { IsDateTime: true })
 				return ticks.Value.ToDateTime();
 			// Could be sql guid so normalize byte order and re-run
-#if !NETFRAMEWORK && !NETSTANDARD
+#if NET6_0_OR_GREATER
 			Span<byte> sqlBytes = stackalloc byte[16];
-			(bytes).WriteFromSqlByteOrder(sqlBytes);
-			ticks = (sqlBytes).ToTicks();
+			bytes.WriteFromSqlByteOrder(sqlBytes);
+			ticks = sqlBytes.ToTicks();
 #else
 			ticks = bytes.FromSqlByteOrder().ToTicks();
 #endif
@@ -55,11 +55,11 @@ public static class GuidExtensions
 		/// <returns>A <see cref="SqlGuid"/> representation of the provided <see cref="Guid"/>.</returns>
 		public SqlGuid ToSqlGuid()
 		{
-#if !NETFRAMEWORK && !NETSTANDARD
+#if NET6_0_OR_GREATER
 			Span<byte> src = stackalloc byte[16];
 			id.TryWriteBytes(src);
 			Span<byte> dst = stackalloc byte[16];
-			(src).WriteToSqlByteOrder(dst);
+			src.WriteToSqlByteOrder(dst);
 			return new(new Guid(dst));
 #else
 			return new(id.ToByteArray().ToSqlByteOrder());
@@ -68,10 +68,10 @@ public static class GuidExtensions
 
 		internal long ToUnixMs()
 		{
-#if !NETFRAMEWORK && !NETSTANDARD
+#if NET6_0_OR_GREATER
 			Span<byte> bytes = stackalloc byte[16];
 			id.TryWriteBytes(bytes);
-			return (bytes).Rfc9562V7UnixMs;
+			return bytes.Rfc9562V7UnixMs;
 #else
 			return id.ToByteArray().Rfc9562V7UnixMs;
 #endif

--- a/src/SequentialGuid/GuidExtensions.cs
+++ b/src/SequentialGuid/GuidExtensions.cs
@@ -65,16 +65,5 @@ public static class GuidExtensions
 			return new(id.ToByteArray().ToSqlByteOrder());
 #endif
 		}
-
-		internal long ToUnixMs()
-		{
-#if NET6_0_OR_GREATER
-			Span<byte> bytes = stackalloc byte[16];
-			id.TryWriteBytes(bytes);
-			return bytes.Rfc9562V7UnixMs;
-#else
-			return id.ToByteArray().Rfc9562V7UnixMs;
-#endif
-		}
 	}
 }

--- a/src/SequentialGuid/GuidNameBased.cs
+++ b/src/SequentialGuid/GuidNameBased.cs
@@ -1,0 +1,44 @@
+using System.Security.Cryptography;
+
+namespace SequentialGuid;
+
+internal static class GuidNameBased
+{
+	internal static class Namespaces
+	{
+		internal static readonly Guid Dns = new("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+		internal static readonly Guid Url = new("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+		internal static readonly Guid Oid = new("6ba7b812-9dad-11d1-80b4-00c04fd430c8");
+		internal static readonly Guid X500 = new("6ba7b814-9dad-11d1-80b4-00c04fd430c8");
+	}
+
+	internal static Guid Create(Guid namespaceId, byte[] name, HashAlgorithmName algorithmName, byte version)
+	{
+#if NETFRAMEWORK
+		using var sha = HashAlgorithm.Create(algorithmName.Name)!;
+		var nsBytes = namespaceId.ToByteArray().SwapByteOrder();
+		sha.TransformBlock(nsBytes, 0, 16, null, 0);
+		sha.TransformFinalBlock(name, 0, name.Length);
+		var digest = sha.Hash;
+#else
+		using var hash = IncrementalHash.CreateHash(algorithmName);
+		hash.AppendData(namespaceId
+#if NETSTANDARD
+			.ToByteArray().SwapByteOrder()
+#else
+			.ToByteArray(true)
+#endif
+		);
+		hash.AppendData(name);
+		var digest = hash.GetHashAndReset();
+#endif
+		digest.SetRfc9562Version(version);
+		digest.SetRfc9562Variant();
+		return
+#if NET6_0_OR_GREATER
+			new(digest.AsSpan(0, 16), true);
+#else
+			new(digest.SwapByteOrder());
+#endif
+	}
+}

--- a/src/SequentialGuid/GuidV4.cs
+++ b/src/SequentialGuid/GuidV4.cs
@@ -21,21 +21,21 @@ public static class GuidV4
 	{
 		// Build 16 bytes in network (big-endian) byte order per RFC 9562 Section 5.4
 		var bytes = new byte[16];
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NET6_0_OR_GREATER
+		RandomNumberGenerator.Fill(bytes);
+#else
 		using var rng = RandomNumberGenerator.Create();
 		rng.GetBytes(bytes);
-#else
-		RandomNumberGenerator.Fill(bytes);
 #endif
 		bytes.SetRfc9562Version(4);
 		bytes.SetRfc9562Variant();
 
 		// Swap from network byte order to .NET's mixed-endian Guid format
 		return
-#if NETFRAMEWORK || NETSTANDARD
-			new(bytes.SwapByteOrder());
-#else
+#if NET6_0_OR_GREATER
 			new(bytes, true);
+#else
+			new(bytes.SwapByteOrder());
 #endif
 	}
 }

--- a/src/SequentialGuid/GuidV5.cs
+++ b/src/SequentialGuid/GuidV5.cs
@@ -15,16 +15,16 @@ public static class GuidV5
 	public static class Namespaces
 	{
 		/// <summary>Name string is a fully-qualified domain name.</summary>
-		public static readonly Guid Dns = new("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+		public static readonly Guid Dns = GuidNameBased.Namespaces.Dns;
 
 		/// <summary>Name string is a URL.</summary>
-		public static readonly Guid Url = new("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+		public static readonly Guid Url = GuidNameBased.Namespaces.Url;
 
 		/// <summary>Name string is an ISO OID.</summary>
-		public static readonly Guid Oid = new("6ba7b812-9dad-11d1-80b4-00c04fd430c8");
+		public static readonly Guid Oid = GuidNameBased.Namespaces.Oid;
 
 		/// <summary>Name string is an X.500 DN (in DER or a text output format).</summary>
-		public static readonly Guid X500 = new("6ba7b814-9dad-11d1-80b4-00c04fd430c8");
+		public static readonly Guid X500 = GuidNameBased.Namespaces.X500;
 	}
 
 	/// <summary>
@@ -42,35 +42,8 @@ public static class GuidV5
 	/// <param name="namespaceId">The namespace UUID.</param>
 	/// <param name="name">The raw name bytes within the namespace.</param>
 	/// <returns>A deterministic version 5 <see cref="Guid"/> derived from the namespace and name.</returns>
-	public static Guid Create(Guid namespaceId, byte[] name)
-	{
 #pragma warning disable CA5350 // SHA-1 is required by RFC 9562 for UUID version 5
-#if NETFRAMEWORK
-		using var sha = SHA1.Create();
-		var nsBytes = namespaceId.ToByteArray().SwapByteOrder();
-		sha.TransformBlock(nsBytes, 0, 16, null, 0);
-		sha.TransformFinalBlock(name, 0, name.Length);
-		var digest = sha.Hash!;
-#else
-		using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA1);
-		hash.AppendData(namespaceId
-#if NETSTANDARD
-			.ToByteArray().SwapByteOrder()
-#else
-			.ToByteArray(true)
-#endif
-		);
-		hash.AppendData(name);
-		var digest = hash.GetHashAndReset();
-#endif
+	public static Guid Create(Guid namespaceId, byte[] name) =>
+		GuidNameBased.Create(namespaceId, name, HashAlgorithmName.SHA1, 5);
 #pragma warning restore CA5350
-		digest.SetRfc9562Version(5);
-		digest.SetRfc9562Variant();
-		return
-#if NETFRAMEWORK || NETSTANDARD
-			new(digest.SwapByteOrder());
-#else
-			new(digest.AsSpan(0, 16), true);
-#endif
-	}
 }

--- a/src/SequentialGuid/GuidV7.cs
+++ b/src/SequentialGuid/GuidV7.cs
@@ -25,11 +25,11 @@ public static class GuidV7
 
 	static GuidV7()
 	{
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NET6_0_OR_GREATER
+		s_counter = RandomNumberGenerator
+#else
 		using var rng = RandomNumberGenerator.Create();
 		s_counter = rng
-#else
-		s_counter = RandomNumberGenerator
 #endif
 			.GetInt32(0x200); // seed in [0, 512) to leave ample headroom before the 12-bit wrap
 	}
@@ -137,13 +137,12 @@ public static class GuidV7
 		var bytes = new byte[16];
 
 		// Fill rand_b (octets 8-15) with random data
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NET6_0_OR_GREATER
+		RandomNumberGenerator.Fill(bytes.AsSpan(8));
+#else
 		using var rng = RandomNumberGenerator.Create();
 		rng.GetBytes(bytes, 8, 8);
-#else
-		RandomNumberGenerator.Fill(bytes.AsSpan(8));
 #endif
-
 		// unix_ts_ms: 48-bit big-endian millisecond timestamp (octets 0-5)
 		bytes[0] = (byte)(unixMilliseconds >> 40);
 		bytes[1] = (byte)(unixMilliseconds >> 32);
@@ -161,10 +160,10 @@ public static class GuidV7
 
 		// Swap from network byte order to .NET's mixed-endian Guid format
 		return
-#if NETFRAMEWORK || NETSTANDARD
-			new(bytes.SwapByteOrder());
-#else
+#if NET6_0_OR_GREATER
 			new(bytes, true);
+#else
+			new(bytes.SwapByteOrder());
 #endif
 	}
 }

--- a/src/SequentialGuid/GuidV7.cs
+++ b/src/SequentialGuid/GuidV7.cs
@@ -7,20 +7,21 @@ namespace SequentialGuid;
 /// to produce time-ordered, monotonically increasing <see cref="Guid"/> values.
 /// </summary>
 /// <remarks>
-/// Implements RFC 9562 Section 6.2 Method 1 (Fixed Bit-Length Dedicated Counter): the 12-bit
-/// <c>rand_a</c> field immediately following the timestamp is used as a monotonic counter,
-/// guaranteeing sort order within the same millisecond. The counter is a process-global,
-/// ever-incrementing value advanced via <see cref="Interlocked.Increment(ref int)"/> and seeded
-/// randomly at startup, mirroring the approach used by <see cref="GuidV8Time"/>. This design is
-/// race-free: concurrent callers each claim a unique, strictly increasing counter slot regardless
-/// of the timestamp they supply. The counter wraps every 4096 increments; callers generating
-/// more than 4096 UUIDs within the same millisecond may observe out-of-order values at the
-/// wrap boundary.
+/// Implements RFC 9562 Section 6.2 Method 1 (Fixed Bit-Length Dedicated Counter): a 26-bit
+/// monotonic counter occupies the 12-bit <c>rand_a</c> field (upper 12 bits) and the first
+/// 14 bits of <c>rand_b</c> after the variant (lower 14 bits), guaranteeing sort order within
+/// the same millisecond. The counter is a process-global, ever-incrementing value advanced via
+/// <see cref="Interlocked.Increment(ref int)"/> and seeded randomly at startup, mirroring the
+/// approach used by <see cref="GuidV8Time"/>. This design is race-free: concurrent callers each
+/// claim a unique, strictly increasing counter slot regardless of the timestamp they supply.
+/// The counter wraps every 67,108,864 increments; callers generating more than 67,108,864 UUIDs
+/// within the same millisecond may observe out-of-order values at the wrap boundary.
 /// </remarks>
 public static class GuidV7
 {
 	// Process-global monotonic counter for RFC 9562 §6.2 Method 1 — Fixed Bit-Length Dedicated
-	// Counter. Advanced via Interlocked.Increment; low 12 bits are written to rand_a.
+	// Counter. Advanced via Interlocked.Increment; upper 12 bits written to rand_a, lower 14 bits
+	// to the first 14 bits of rand_b (after variant). Masked to 26 bits (0x3FFFFFF).
 	private static int s_counter;
 
 	static GuidV7()
@@ -31,7 +32,7 @@ public static class GuidV7
 		using var rng = RandomNumberGenerator.Create();
 		s_counter = rng
 #endif
-			.GetInt32(0x200); // seed in [0, 512) to leave ample headroom before the 12-bit wrap
+			.GetInt32(0x200); // seed in [0, 512) to leave ample headroom before the 26-bit wrap
 	}
 
 	/// <summary>
@@ -131,17 +132,17 @@ public static class GuidV7
 
 		// RFC 9562 §6.2 Method 1: claim a unique slot in the monotonic counter.
 		// Mirrors GuidV8Time.NewGuid: no timestamp-tracking state, no CAS loop.
-		var counter = Interlocked.Increment(ref s_counter) & 0xFFF;
+		var counter = Interlocked.Increment(ref s_counter) & 0x3FFFFFF; // 26-bit counter (12 rand_a + 14 rand_b)
 
 		// Build 16 bytes in network (big-endian) byte order per RFC 9562 Section 5.7
 		var bytes = new byte[16];
 
-		// Fill rand_b (octets 8-15) with random data
+		// Fill rand_b tail (octets 10-15) with random data; octets 8-9 hold the counter extension
 #if NET6_0_OR_GREATER
-		RandomNumberGenerator.Fill(bytes.AsSpan(8));
+		RandomNumberGenerator.Fill(bytes.AsSpan(10));
 #else
 		using var rng = RandomNumberGenerator.Create();
-		rng.GetBytes(bytes, 8, 8);
+		rng.GetBytes(bytes, 10, 6);
 #endif
 		// unix_ts_ms: 48-bit big-endian millisecond timestamp (octets 0-5)
 		bytes[0] = (byte)(unixMilliseconds >> 40);
@@ -151,9 +152,13 @@ public static class GuidV7
 		bytes[4] = (byte)(unixMilliseconds >> 8);
 		bytes[5] = (byte)unixMilliseconds;
 
-		// rand_a: 12-bit counter (octets 6-7)
-		bytes[6] = (byte)(counter >> 8);
-		bytes[7] = (byte)(counter & 0xFF);
+		// rand_a: upper 12 bits of 26-bit counter (octets 6-7)
+		bytes[6] = (byte)(counter >> 22);          // counter bits 25-22 (lower nibble; version takes upper)
+		bytes[7] = (byte)((counter >> 14) & 0xFF); // counter bits 21-14
+
+		// rand_b extension: lower 14 bits of counter (octets 8-9; variant takes upper 2 bits of octet 8)
+		bytes[8] = (byte)((counter >> 8) & 0x3F);  // counter bits 13-8
+		bytes[9] = (byte)(counter & 0xFF);          // counter bits 7-0
 
 		bytes.SetRfc9562Version(7);
 		bytes.SetRfc9562Variant();

--- a/src/SequentialGuid/GuidV8Name.cs
+++ b/src/SequentialGuid/GuidV8Name.cs
@@ -23,16 +23,16 @@ public static class GuidV8Name
 	public static class Namespaces
 	{
 		/// <summary>Name string is a fully-qualified domain name.</summary>
-		public static readonly Guid Dns = new("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+		public static readonly Guid Dns = GuidNameBased.Namespaces.Dns;
 
 		/// <summary>Name string is a URL.</summary>
-		public static readonly Guid Url = new("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+		public static readonly Guid Url = GuidNameBased.Namespaces.Url;
 
 		/// <summary>Name string is an ISO OID.</summary>
-		public static readonly Guid Oid = new("6ba7b812-9dad-11d1-80b4-00c04fd430c8");
+		public static readonly Guid Oid = GuidNameBased.Namespaces.Oid;
 
 		/// <summary>Name string is an X.500 DN (in DER or a text output format).</summary>
-		public static readonly Guid X500 = new("6ba7b814-9dad-11d1-80b4-00c04fd430c8");
+		public static readonly Guid X500 = GuidNameBased.Namespaces.X500;
 	}
 
 	/// <summary>
@@ -50,33 +50,6 @@ public static class GuidV8Name
 	/// <param name="namespaceId">The namespace UUID.</param>
 	/// <param name="name">The raw name bytes within the namespace.</param>
 	/// <returns>A deterministic version 8 <see cref="Guid"/> derived from the namespace and name.</returns>
-	public static Guid Create(Guid namespaceId, byte[] name)
-	{
-#if NETFRAMEWORK
-		using var sha = SHA256.Create();
-		var nsBytes = namespaceId.ToByteArray().SwapByteOrder();
-		sha.TransformBlock(nsBytes, 0, 16, null, 0);
-		sha.TransformFinalBlock(name, 0, name.Length);
-		var digest = sha.Hash!;
-#else
-		using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-		hash.AppendData(namespaceId
-#if NETSTANDARD
-			.ToByteArray().SwapByteOrder()
-#else
-			.ToByteArray(true)
-#endif
-		);
-		hash.AppendData(name);
-		var digest = hash.GetHashAndReset();
-#endif
-		digest.SetRfc9562Version(8);
-		digest.SetRfc9562Variant();
-		return
-#if NETFRAMEWORK || NETSTANDARD
-			new(digest.SwapByteOrder());
-#else
-			new(digest.AsSpan(0, 16), true);
-#endif
-	}
+	public static Guid Create(Guid namespaceId, byte[] name) =>
+		GuidNameBased.Create(namespaceId, name, HashAlgorithmName.SHA256, 8);
 }

--- a/src/SequentialGuid/GuidV8Time.cs
+++ b/src/SequentialGuid/GuidV8Time.cs
@@ -159,21 +159,41 @@ public static class GuidV8Time
 	{
 		// only use low order 22 bits
 		var increment = Interlocked.Increment(ref s_increment) & 0x003fffff;
-		// RFC 9562 §B.1 UUIDv8 time-based layout:
-		//   custom_a [48 bits] = timestamp[59:12] → Guid.a (32 bits) + Guid.b (16 bits)
-		//   ver      [ 4 bits] = 0x8              → high nibble of Guid.c
-		//   custom_b [12 bits] = timestamp[11:0]  → low 12 bits of Guid.c
-		//   var      [ 2 bits] = 0b10             → top 2 bits of d[0]
-		//   custom_c [62 bits] = increment + machinePid → d[0] (lower 6 bits) + d[1..7]
-		return new(
-			(int)(timestamp >> 28),
-			(short)(timestamp >> 12),
-			(short)(0x8000 | (timestamp & 0x0FFF)),
-			[
-				(byte)(((increment >> 16) & 0x3F) | 0x80),
-				(byte)(increment >> 8), (byte)increment,
-				MachinePid[0], MachinePid[1], MachinePid[2], MachinePid[3], MachinePid[4]
-			]
-		);
+
+		// Build 16 bytes in network (big-endian) byte order per RFC 9562 Appendix B.1
+		var bytes = new byte[16];
+
+		// custom_a: timestamp bits [59:12] → octets 0-5
+		bytes[0] = (byte)(timestamp >> 52);
+		bytes[1] = (byte)(timestamp >> 44);
+		bytes[2] = (byte)(timestamp >> 36);
+		bytes[3] = (byte)(timestamp >> 28);
+		bytes[4] = (byte)(timestamp >> 20);
+		bytes[5] = (byte)(timestamp >> 12);
+
+		// custom_b: timestamp bits [11:0] → octets 6-7 (version takes upper nibble of octet 6)
+		bytes[6] = (byte)((timestamp >> 8) & 0x0F);
+		bytes[7] = (byte)timestamp;
+
+		// custom_c: increment[21:0] + MachinePid → octets 8-15 (variant takes upper 2 bits of octet 8)
+		bytes[8] = (byte)((increment >> 16) & 0x3F);
+		bytes[9] = (byte)(increment >> 8);
+		bytes[10] = (byte)increment;
+		bytes[11] = MachinePid[0];
+		bytes[12] = MachinePid[1];
+		bytes[13] = MachinePid[2];
+		bytes[14] = MachinePid[3];
+		bytes[15] = MachinePid[4];
+
+		bytes.SetRfc9562Version(8);
+		bytes.SetRfc9562Variant();
+
+		// Swap from network byte order to .NET's mixed-endian Guid format
+		return
+#if NET6_0_OR_GREATER
+			new(bytes, true);
+#else
+			new(bytes.SwapByteOrder());
+#endif
 	}
 }

--- a/src/SequentialGuid/GuidV8Time.cs
+++ b/src/SequentialGuid/GuidV8Time.cs
@@ -27,13 +27,13 @@ public static class GuidV8Time
 
 	static GuidV8Time()
 	{
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NET6_0_OR_GREATER
+		// Use the RandomNumberGenerator static function where available
+		s_increment = RandomNumberGenerator
+#else
 		// Fall back to the old Random create function
 		using var rng = RandomNumberGenerator.Create();
 		s_increment = rng
-#else
-		// Use the RandomNumberGenerator static function where available
-		s_increment = RandomNumberGenerator
 #endif
 			.GetInt32(500000);
 		MachinePid = new byte[5];

--- a/src/SequentialGuid/RandomNumberGeneratorExtensions.cs
+++ b/src/SequentialGuid/RandomNumberGeneratorExtensions.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if !NET6_0_OR_GREATER
 using System.Security.Cryptography;
 
 namespace SequentialGuid;

--- a/src/SequentialGuid/SkipLocalsInitPolyfill.cs
+++ b/src/SequentialGuid/SkipLocalsInitPolyfill.cs
@@ -1,13 +1,13 @@
-#if NETFRAMEWORK || NETSTANDARD
+#if !NET6_0_OR_GREATER
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices;
+
 // SkipLocalsInitAttribute is available from .NET 5+ / .NET Standard 2.1+.
 // Provide a no-op shim so the attribute can be applied unconditionally.
-namespace System.Runtime.CompilerServices
-{
-	[AttributeUsage(
-		AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct |
-		AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property |
-		AttributeTargets.Event | AttributeTargets.Interface,
-		Inherited = false)]
-	internal sealed class SkipLocalsInitAttribute : Attribute { }
-}
+[AttributeUsage(
+	AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct |
+	AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property |
+	AttributeTargets.Event | AttributeTargets.Interface,
+	Inherited = false)]
+internal sealed class SkipLocalsInitAttribute : Attribute;
 #endif

--- a/src/SequentialGuid/SqlGuidExtensions.cs
+++ b/src/SequentialGuid/SqlGuidExtensions.cs
@@ -30,14 +30,14 @@ public static class SqlGuidExtensions
 		/// <returns>A <see cref="Guid"/> representation of the specified <see cref="SqlGuid"/>.</returns>
 		public Guid ToGuid()
 		{
-#if !NETFRAMEWORK && !NETSTANDARD
+#if NET6_0_OR_GREATER
 			Span<byte> src = stackalloc byte[16];
 			sqlGuid.Value.TryWriteBytes(src);
 			Span<byte> dst = stackalloc byte[16];
 			src.WriteFromSqlByteOrder(dst);
 			return new(dst);
 #else
-			return new(sqlGuid.ToByteArray()!.FromSqlByteOrder());
+			return new(sqlGuid.ToByteArray().FromSqlByteOrder());
 #endif
 		}
 	}

--- a/test/SequentialGuid.NodaTime.Tests/SequentialGuid.NodaTime.Tests.csproj
+++ b/test/SequentialGuid.NodaTime.Tests/SequentialGuid.NodaTime.Tests.csproj
@@ -7,7 +7,7 @@
 		<Using Remove="System.Threading" />
 		<Using Remove="System.Threading.Tasks" />
 	</ItemGroup>
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' != 'net472'">
 		<PackageReference Include="NodaTime" Version="3.*" />
 	</ItemGroup>
 

--- a/test/SequentialGuid.Tests/ByteArrayExtensions.cs
+++ b/test/SequentialGuid.Tests/ByteArrayExtensions.cs
@@ -1,0 +1,15 @@
+namespace SequentialGuid.Tests;
+
+internal static class ByteArrayExtensions
+{
+	extension(byte[] b)
+	{
+		// For SQL byte order the variant is the 7th byte
+		internal bool SqlVariantIsRfc9562() =>
+			(b[6] & 0xC0) == 0x80;
+
+		// In sql byte order the 11th byte was always 8
+		internal bool IsSqlLegacy() =>
+			b[10] == 8 && !b.SqlVariantIsRfc9562();
+	}
+}

--- a/test/SequentialGuid.Tests/GuidExtensions.cs
+++ b/test/SequentialGuid.Tests/GuidExtensions.cs
@@ -1,0 +1,18 @@
+namespace SequentialGuid.Tests;
+
+internal static class GuidExtensions
+{
+	extension(Guid id)
+	{
+		internal long ToUnixMs()
+		{
+#if NET6_0_OR_GREATER
+			Span<byte> bytes = stackalloc byte[16];
+			id.TryWriteBytes(bytes);
+			return bytes.Rfc9562V7UnixMs();
+#else
+			return id.ToByteArray().Rfc9562V7UnixMs();
+#endif
+		}
+	}
+}

--- a/test/SequentialGuid.Tests/GuidExtensions.cs
+++ b/test/SequentialGuid.Tests/GuidExtensions.cs
@@ -4,15 +4,7 @@ internal static class GuidExtensions
 {
 	extension(Guid id)
 	{
-		internal long ToUnixMs()
-		{
-#if NET6_0_OR_GREATER
-			Span<byte> bytes = stackalloc byte[16];
-			id.TryWriteBytes(bytes);
-			return bytes.Rfc9562V7UnixMs();
-#else
-			return id.ToByteArray().Rfc9562V7UnixMs();
-#endif
-		}
+		internal long ToUnixMs() =>
+			id.ToByteArray().Rfc9562V7UnixMs();
 	}
 }

--- a/test/SequentialGuid.Tests/GuidV7Tests.cs
+++ b/test/SequentialGuid.Tests/GuidV7Tests.cs
@@ -24,13 +24,12 @@ public sealed class GuidV7Tests
 	{
 		// Act
 		var id = GuidV7.NewGuid();
-		var bytes = id.ToByteArray();
-		var sqlBytes = bytes.ToSqlByteOrder();
+		var sqlId = id.ToSqlGuid();
 #if NET9_0_OR_GREATER
 		id.Variant.ShouldBeInRange(8, 11);
 #endif
-		bytes.VariantIsRfc9562().ShouldBeTrue();
-		sqlBytes.SqlVariantIsRfc9562().ShouldBeTrue();
+		id.ToByteArray().VariantIsRfc9562().ShouldBeTrue();
+		sqlId.ToByteArray()!.SqlVariantIsRfc9562().ShouldBeTrue();
 	}
 
 	[Fact]

--- a/test/SequentialGuid.Tests/GuidV7Tests.cs
+++ b/test/SequentialGuid.Tests/GuidV7Tests.cs
@@ -171,7 +171,7 @@ public sealed class GuidV7Tests
 	void TestSameTimestampBatchIsMonotonicallyOrdered()
 	{
 		// Arrange - use the current time so the counter path is exercised
-		// (RFC 9562 §6.2 Method 1: fixed bit-length dedicated counter in rand_a)
+		// (RFC 9562 §6.2 Method 1: fixed bit-length dedicated counter spanning rand_a and rand_b)
 		var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 		// Act - generate 100 UUIDs all sharing the same millisecond timestamp
 		Guid[] actual = [.. Enumerable.Range(0, 100).Select(_ => GuidV7.NewGuid(timestamp))];

--- a/test/SequentialGuid.Tests/GuidV8TimeTests.cs
+++ b/test/SequentialGuid.Tests/GuidV8TimeTests.cs
@@ -22,13 +22,12 @@ public sealed class GuidV8TimeTests
 	{
 		// Act
 		var id = GuidV8Time.NewGuid();
-		var bytes = id.ToByteArray();
-		var sqlBytes = bytes.ToSqlByteOrder();
+		var sqlId = id.ToSqlGuid();
 #if NET9_0_OR_GREATER
 		id.Variant.ShouldBeInRange(8, 11);
 #endif
-		bytes.VariantIsRfc9562().ShouldBeTrue();
-		sqlBytes.SqlVariantIsRfc9562().ShouldBeTrue();
+		id.ToByteArray().VariantIsRfc9562().ShouldBeTrue();
+		sqlId.ToByteArray()!.SqlVariantIsRfc9562().ShouldBeTrue();
 	}
 
 	[Fact]

--- a/test/SequentialGuid.Tests/SequentialGuidTests.cs
+++ b/test/SequentialGuid.Tests/SequentialGuidTests.cs
@@ -296,7 +296,7 @@ public sealed class SequentialGuidTests
 
 	[Fact]
 	void TestAfterNowReturnsNullDateTime() =>
-		TestReturnsNullDateTime(DateTime.UtcNow.AddSeconds(1).Ticks);
+		TestReturnsNullDateTime(DateTime.UtcNow.AddMinutes(1).Ticks);
 
 	[Fact]
 	void TestBeforeUnixEpochThrowsArgumentException() =>
@@ -311,7 +311,7 @@ public sealed class SequentialGuidTests
 	{
 		//Arrange
 		var guid = GuidV8Time.NewGuid(ticks);
-		var sqlGuid = GuidV8Time.NewGuid(ticks);
+		var sqlGuid = guid.ToSqlGuid();
 		//Act & Assert
 		guid.ToDateTime().ShouldBeNull();
 		sqlGuid.ToDateTime().ShouldBeNull();

--- a/test/SequentialGuid.Tests/SequentialGuidTests.cs
+++ b/test/SequentialGuid.Tests/SequentialGuidTests.cs
@@ -160,13 +160,12 @@ public sealed class SequentialGuidTests
 	{
 		// Act
 		var id = GuidV8Time.NewGuid();
-		var bytes = id.ToByteArray();
-		var sqlBytes = bytes.ToSqlByteOrder();
+		var sqlId = id.ToSqlGuid();
 #if NET9_0_OR_GREATER
 		id.Variant.ShouldBeInRange(8, 11);
 #endif
-		bytes.VariantIsRfc9562().ShouldBeTrue();
-		sqlBytes.SqlVariantIsRfc9562().ShouldBeTrue();
+		id.ToByteArray().VariantIsRfc9562().ShouldBeTrue();
+		sqlId.ToByteArray()!.SqlVariantIsRfc9562().ShouldBeTrue();
 	}
 
 	[Fact]
@@ -2502,8 +2501,8 @@ public sealed class SequentialGuidTests
 		foreach (var input in legacy)
 		{
 			var bytes = input.ToByteArray();
-			var sqlBytes = bytes.ToSqlByteOrder();
-
+			var sqlId = input.ToSqlGuid();
+			var sqlBytes = sqlId.ToByteArray()!;
 			// As long as we hit the following flags we can render the timestamps
 			bytes.IsLegacy().ShouldBeTrue();
 			bytes.IsSqlLegacy().ShouldBeFalse();


### PR DESCRIPTION
Move as much stuff up to the test project as I can and make sure the bytearray extensions have either optimized versions or unoptimized versions depending on TFM but never both.  Also remove all the redundancy from GuidV5 and GuidV8Name.  Very little remains in this version :)