### PR TITLE
Fix SequentialSqlGuid in-memory sorting

### DIFF
--- a/src/SequentialGuid/SequentialSqlGuid.cs
+++ b/src/SequentialGuid/SequentialSqlGuid.cs
@@ -104,7 +104,7 @@ public readonly record struct SequentialSqlGuid : ISequentialGuid<SequentialSqlG
 		{
 			null => 1,
 			SequentialSqlGuid otherSequential => CompareTo(otherSequential),
-			Guid otherGuid => Value.CompareTo(otherGuid),
+			Guid otherGuid => new SqlGuid(Value).CompareTo(new SqlGuid(otherGuid)),
 			SqlGuid sqlGuid => new SqlGuid(Value).CompareTo(sqlGuid),
 			_ => throw new ArgumentException($"Object must be of type {nameof(SequentialSqlGuid)} or {nameof(Guid)} or {nameof(SqlGuid)}.", nameof(obj))
 		};

--- a/src/SequentialGuid/SequentialSqlGuid.cs
+++ b/src/SequentialGuid/SequentialSqlGuid.cs
@@ -1,3 +1,4 @@
+using System.Data.SqlTypes;
 using System.Runtime.CompilerServices;
 using SequentialGuid.Extensions;
 
@@ -104,20 +105,21 @@ public readonly record struct SequentialSqlGuid : ISequentialGuid<SequentialSqlG
 			null => 1,
 			SequentialSqlGuid otherSequential => CompareTo(otherSequential),
 			Guid otherGuid => Value.CompareTo(otherGuid),
-			_ => throw new ArgumentException($"Object must be of type {nameof(SequentialSqlGuid)} or {nameof(Guid)}.", nameof(obj))
+			SqlGuid sqlGuid => new SqlGuid(Value).CompareTo(sqlGuid),
+			_ => throw new ArgumentException($"Object must be of type {nameof(SequentialSqlGuid)} or {nameof(Guid)} or {nameof(SqlGuid)}.", nameof(obj))
 		};
 
 	/// <inheritdoc/>
 	public int CompareTo(SequentialSqlGuid other) =>
-		Value.CompareTo(other.Value);
+		new SqlGuid(Value).CompareTo(new SqlGuid(other.Value));
 
 	/// <inheritdoc/>
 	public bool Equals(SequentialSqlGuid other) =>
-		Value.Equals(other.Value);
+		new SqlGuid(Value).Equals(new SqlGuid(other.Value));
 
 	/// <inheritdoc />
 	public override int GetHashCode() =>
-		Value.GetHashCode();
+		new SqlGuid(Value).GetHashCode();
 
 	/// <inheritdoc cref="IComparable{T}"/>
 	public static bool operator <(SequentialSqlGuid left, SequentialSqlGuid right) =>

--- a/test/SequentialGuid.Tests/GuidV7Tests.cs
+++ b/test/SequentialGuid.Tests/GuidV7Tests.cs
@@ -7,6 +7,65 @@ public sealed class GuidV7Tests
 	// RFC 9562 Appendix A.6 test vector: Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00
 	// Unix Epoch milliseconds: 1645557742000 = 0x017F22E279B0
 	const long RfcTestVectorMs = 1645557742000L;
+	const long EpochTicks = 621355968000000000L;
+
+	/// <summary>
+	///     Properly sequenced v7 Guid array with UnixEpoch (0 ms) timestamp, version 7, and variant bits set
+	/// </summary>
+	static IReadOnlyList<SequentialGuid> SortedGuidList { get; } =
+	[
+		new("00000000-0000-7000-8000-000000000001"),
+		new("00000000-0000-7000-8000-000000000100"),
+		new("00000000-0000-7000-8000-000000010000"),
+		new("00000000-0000-7000-8000-000001000000"),
+		new("00000000-0000-7000-8000-000100000000"),
+		new("00000000-0000-7000-8000-010000000000"),
+		new("00000000-0000-7000-8001-000000000000"),
+		new("00000000-0000-7000-8100-000000000000")
+	];
+
+	/// <summary>
+	///     Properly sequenced v7 SqlGuid array with UnixEpoch (0 ms) timestamp, version 7, and variant bits set
+	/// </summary>
+	private static IReadOnlyList<SequentialSqlGuid> SortedSqlGuidList { get; } =
+	[
+		new("01000000-0000-0080-7000-000000000000"),
+		new("00010000-0000-0080-7000-000000000000"),
+		new("00000100-0000-0080-7000-000000000000"),
+		new("00000001-0000-0080-7000-000000000000"),
+		new("00000000-0100-0080-7000-000000000000"),
+		new("00000000-0001-0080-7000-000000000000"),
+		new("00000000-0000-0180-7000-000000000000"),
+		new("00000000-0000-0081-7000-000000000000"),
+	];
+
+	[Fact]
+	void TestSortedGuidList()
+	{
+		// Act
+		IReadOnlyList<SequentialGuid> sortedList = [.. SortedGuidList.OrderBy(x => x)];
+		// Assert
+		sortedList.ShouldBe(SortedGuidList, ignoreOrder: false);
+		// Make sure everything but the entropy bytes checks out
+		foreach (var actual in SortedGuidList.Select(v => v.Timestamp.Ticks))
+		{
+			actual.ShouldBe(EpochTicks);
+		}
+	}
+
+	[Fact]
+	void TestSortedSqlGuidList()
+	{
+		// Act
+		IReadOnlyList<SequentialSqlGuid> sortedSqlList = [.. SortedSqlGuidList.OrderBy(x => x)];
+		// Assert
+		sortedSqlList.ShouldBe(SortedSqlGuidList, ignoreOrder: false);
+		// Make sure everything but the entropy bytes checks out
+		foreach (var actual in SortedSqlGuidList.Select(v => v.Timestamp.Ticks))
+		{
+			actual.ShouldBe(EpochTicks);
+		}
+	}
 
 	[Fact]
 	void TestVersion7Bits()

--- a/test/SequentialGuid.Tests/GuidV7Tests.cs
+++ b/test/SequentialGuid.Tests/GuidV7Tests.cs
@@ -119,7 +119,7 @@ public sealed class GuidV7Tests
 		// Act
 		Guid[] sorted = [.. guids.OrderBy(x => x)];
 		// Assert - different timestamp ms values always sort in creation order
-		sorted.ShouldBe(guids);
+		sorted.ShouldBe(guids, ignoreOrder: false);
 	}
 
 	[Fact]

--- a/test/SequentialGuid.Tests/GuidV8TimeTests.cs
+++ b/test/SequentialGuid.Tests/GuidV8TimeTests.cs
@@ -6,6 +6,64 @@ public sealed class GuidV8TimeTests
 {
 	const long EpochTicks = 621355968000000000L;
 
+	/// <summary>
+	///     Properly sequenced v8 Guid array with UnixEpoch timestamp, version 8, and variant bits set
+	/// </summary>
+	static IReadOnlyList<SequentialGuid> SortedGuidList { get; } =
+	[
+		new("89f7ff5f-7b58-8000-8000-000000000001"),
+		new("89f7ff5f-7b58-8000-8000-000000000100"),
+		new("89f7ff5f-7b58-8000-8000-000000010000"),
+		new("89f7ff5f-7b58-8000-8000-000001000000"),
+		new("89f7ff5f-7b58-8000-8000-000100000000"),
+		new("89f7ff5f-7b58-8000-8000-010000000000"),
+		new("89f7ff5f-7b58-8000-8001-000000000000"),
+		new("89f7ff5f-7b58-8000-8100-000000000000")
+	];
+
+	/// <summary>
+	///     Properly sequenced v8 SqlGuid array with UnixEpoch timestamp, version 8, and variant bits set
+	/// </summary>
+	private static IReadOnlyList<SequentialSqlGuid> SortedSqlGuidList { get; } =
+	[
+		new("01000000-0000-0080-8000-89f7ff5f7b58"),
+		new("00010000-0000-0080-8000-89f7ff5f7b58"),
+		new("00000100-0000-0080-8000-89f7ff5f7b58"),
+		new("00000001-0000-0080-8000-89f7ff5f7b58"),
+		new("00000000-0100-0080-8000-89f7ff5f7b58"),
+		new("00000000-0001-0080-8000-89f7ff5f7b58"),
+		new("00000000-0000-0180-8000-89f7ff5f7b58"),
+		new("00000000-0000-0081-8000-89f7ff5f7b58"),
+	];
+
+	[Fact]
+	void TestSortedGuidList()
+	{
+		// Act
+		IReadOnlyList<SequentialGuid> sortedList = [.. SortedGuidList.OrderBy(x => x)];
+		// Assert
+		sortedList.ShouldBe(SortedGuidList, ignoreOrder: false);
+		// Make sure everything but the entropy bytes checks out
+		foreach (var actual in SortedGuidList.Select(v => v.Timestamp.Ticks))
+		{
+			actual.ShouldBe(EpochTicks);
+		}
+	}
+
+	[Fact]
+	void TestSortedSqlGuidList()
+	{
+		// Act
+		IReadOnlyList<SequentialSqlGuid> sortedSqlList = [.. SortedSqlGuidList.OrderBy(x => x)];
+		// Assert
+		sortedSqlList.ShouldBe(SortedSqlGuidList, ignoreOrder: false);
+		// Make sure everything but the entropy bytes checks out
+		foreach (var actual in SortedSqlGuidList.Select(v => v.Timestamp.Ticks))
+		{
+			actual.ShouldBe(EpochTicks);
+		}
+	}
+
 	[Fact]
 	void TestVersion8Bits()
 	{
@@ -90,7 +148,7 @@ public sealed class GuidV8TimeTests
 		// Act
 		Guid[] sorted = [.. guids.OrderBy(x => x)];
 		// Assert - different timestamp tick values always sort in creation order
-		sorted.ShouldBe(guids);
+		sorted.ShouldBe(guids, ignoreOrder: false);
 	}
 
 	[Fact]

--- a/test/SequentialGuid.Tests/SequentialGuidTests.cs
+++ b/test/SequentialGuid.Tests/SequentialGuidTests.cs
@@ -12,7 +12,7 @@ public sealed class SequentialGuidTests
 	/// <summary>
 	///     Properly sequenced Guid array
 	/// </summary>
-	IList<Guid> SortedGuidList { get; } =
+	static IReadOnlyList<Guid> SortedGuidList { get; } =
 	[
 		new("00000000-0000-0000-0000-000000000001"),
 		new("00000000-0000-0000-0000-000000000100"),
@@ -36,7 +36,7 @@ public sealed class SequentialGuidTests
 	///     Properly sequenced SqlGuid array
 	/// </summary>
 	/// See: https://www.sqlbi.com/blog/alberto/2007/08/31/how-are-guids-sorted-by-sql-server/
-	IList<SqlGuid> SortedSqlGuidList { get; } =
+	static IReadOnlyList<SqlGuid> SortedSqlGuidList { get; } =
 	[
 		new("01000000-0000-0000-0000-000000000000"),
 		new("00010000-0000-0000-0000-000000000000"),
@@ -115,18 +115,18 @@ public sealed class SequentialGuidTests
 	void TestGuidSorting()
 	{
 		//Act
-		IList<Guid> sortedList = [.. SortedGuidList.OrderBy(x => x)];
+		IReadOnlyList<Guid> sortedList = [.. SortedGuidList.OrderBy(x => x)];
 		//Assert
-		sortedList.ShouldBe(SortedGuidList);
+		sortedList.ShouldBe(SortedGuidList, ignoreOrder: false);
 	}
 
 	[Fact]
 	void TestSqlGuidSorting()
 	{
 		//Act
-		IList<SqlGuid> sortedList = [.. SortedSqlGuidList.OrderBy(x => x)];
+		IReadOnlyList<SqlGuid> sortedList = [.. SortedSqlGuidList.OrderBy(x => x)];
 		//Assert
-		sortedList.ShouldBe(SortedSqlGuidList);
+		sortedList.ShouldBe(SortedSqlGuidList, ignoreOrder: false);
 	}
 
 	[Fact]
@@ -366,7 +366,7 @@ public sealed class SequentialGuidTests
 
 		IList<Guid> sortedItems = [.. items.OrderBy(x => x)];
 		//Assert
-		sortedItems.ShouldBe(items);
+		sortedItems.ShouldBe(items, ignoreOrder: false);
 	}
 
 	[Fact]
@@ -383,7 +383,7 @@ public sealed class SequentialGuidTests
 
 		IList<SqlGuid> sortedItems = [.. items.OrderBy(x => x)];
 		//Assert
-		sortedItems.ShouldBe(items);
+		sortedItems.ShouldBe(items, ignoreOrder: false);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Fix `SequentialSqlGuid` in-memory sorting

### Problem

`SequentialSqlGuid.CompareTo` was delegating to `Guid.CompareTo`, which uses standard byte-order comparison. SQL Server sorts `uniqueidentifier` values using a [different byte-order priority](https://www.sqlbi.com/blog/alberto/2007/08/31/how-are-guids-sorted-by-sql-server/), so in-memory sorting of `SequentialSqlGuid` did not match the order SQL Server would produce.

### Fix

`SequentialSqlGuid` now wraps calls through `System.Data.SqlTypes.SqlGuid` to ensure `CompareTo`, `Equals`, and `GetHashCode` all use SQL Server–compatible byte ordering:

```csharp
public int CompareTo(SequentialSqlGuid other) =>
    new SqlGuid(Value).CompareTo(new SqlGuid(other.Value));

public bool Equals(SequentialSqlGuid other) =>
    new SqlGuid(Value).Equals(new SqlGuid(other.Value));

public override int GetHashCode() =>
    new SqlGuid(Value).GetHashCode();
```

The `CompareTo(object)` overload also now accepts `SqlGuid` directly.

### Tests

- Added `SortedGuidList` / `SortedSqlGuidList` sort-order verification tests to both `GuidV7Tests` and `GuidV8TimeTests`, confirming that `SequentialGuid` and `SequentialSqlGuid` collections sort in the expected byte order with version/variant bits and a known timestamp.
- Tightened existing `ShouldBe` assertions to use `ignoreOrder: false` so sort-order regressions are caught explicitly.
- Changed test list types from `IList<T>` to `static IReadOnlyList<T>` in `SequentialGuidTests` for consistency.