### PR TITLE
v6.1: zero-alloc deterministic generators + ergonomic helpers

### DIFF
--- a/src/SequentialGuid/Extensions/ByteArrayExtensions.cs
+++ b/src/SequentialGuid/Extensions/ByteArrayExtensions.cs
@@ -220,6 +220,17 @@ internal static class ByteArrayExtensions
 		// Sets the RFC 9562 variant bits (10xxxxxx) on bytes[8]
 		internal void SetRfc9562Variant() =>
 			b[8] = (byte)((b[8] & 0x3F) | 0x80);
+
+		// Swaps the first 16 bytes of `b` between .NET mixed-endian and RFC 9562 network (big-endian)
+		// byte order, in place. Reverses Data1 (4 bytes), Data2 (2 bytes), Data3 (2 bytes); Data4 unchanged.
+		// This mapping is self-inverse: applying it twice returns the original bytes.
+		internal void SwapGuidBytesInPlace()
+		{
+			(b[0], b[3]) = (b[3], b[0]);
+			(b[1], b[2]) = (b[2], b[1]);
+			(b[4], b[5]) = (b[5], b[4]);
+			(b[6], b[7]) = (b[7], b[6]);
+		}
 	}
 #endif
 }

--- a/src/SequentialGuid/Extensions/GuidExtensions.cs
+++ b/src/SequentialGuid/Extensions/GuidExtensions.cs
@@ -53,6 +53,20 @@ public static class GuidExtensions
 				: null;
 		}
 
+		/// <summary>Try-pattern variant of <see cref="ToDateTime"/>.</summary>
+		/// <param name="timestamp">When this method returns <see langword="true"/>, the embedded UTC timestamp; otherwise <c>default</c>.</param>
+		/// <returns><see langword="true"/> if the GUID contains a valid embedded timestamp; otherwise <see langword="false"/>.</returns>
+		public bool TryToDateTime(out DateTime timestamp)
+		{
+			if (id.ToDateTime() is { } dt)
+			{
+				timestamp = dt;
+				return true;
+			}
+			timestamp = default;
+			return false;
+		}
+
 		/// <summary>
 		/// Converts a <see cref="Guid"/> to its SQL Server byte order equivalent.
 		/// </summary>

--- a/src/SequentialGuid/Extensions/GuidExtensions.cs
+++ b/src/SequentialGuid/Extensions/GuidExtensions.cs
@@ -14,8 +14,13 @@ namespace System;
 [SkipLocalsInit]
 public static class GuidExtensions
 {
+	private static readonly Guid s_maxValue = new("ffffffff-ffff-ffff-ffff-ffffffffffff");
+
 	extension(Guid id)
 	{
+		/// <summary>Gets the RFC 9562 §5.10 max UUID — all bits set to 1.</summary>
+		public static Guid MaxValue => s_maxValue;
+
 		/// <summary>
 		/// Converts a <see cref="Guid"/> to a <see cref="DateTime"/> if the <see cref="Guid"/> contains a valid timestamp.
 		/// </summary>

--- a/src/SequentialGuid/Extensions/GuidExtensions.cs
+++ b/src/SequentialGuid/Extensions/GuidExtensions.cs
@@ -86,7 +86,7 @@ public static class GuidExtensions
 			return false;
 		}
 
-		/// <summary>Returns true if <paramref name="id"/> is a recognised sequential GUID (V7, V8, or legacy format) in either standard or SQL Server byte order.</summary>
+		/// <summary>Returns true if this GUID is a recognised sequential GUID (V7, V8, or legacy format) in either standard or SQL Server byte order.</summary>
 		public bool IsSequentialGuid() =>
 			SequentialGuidByteOrder.TryDetect(id, out _);
 

--- a/src/SequentialGuid/Extensions/GuidExtensions.cs
+++ b/src/SequentialGuid/Extensions/GuidExtensions.cs
@@ -67,6 +67,25 @@ public static class GuidExtensions
 			return false;
 		}
 
+		/// <summary>Converts a <see cref="Guid"/> to a <see cref="DateTimeOffset"/> if the GUID contains a valid timestamp.</summary>
+		/// <returns>A <see cref="DateTimeOffset"/> with a zero (UTC) offset, or <c>null</c> if the GUID does not contain a valid timestamp.</returns>
+		public DateTimeOffset? ToDateTimeOffset() =>
+			id.ToDateTime() is { } dt ? new DateTimeOffset(dt, TimeSpan.Zero) : null;
+
+		/// <summary>Try-pattern variant of <see cref="ToDateTimeOffset"/>.</summary>
+		/// <param name="timestamp">When this method returns <see langword="true"/>, the embedded UTC timestamp as a <see cref="DateTimeOffset"/>; otherwise <c>default</c>.</param>
+		/// <returns><see langword="true"/> if the GUID contains a valid embedded timestamp; otherwise <see langword="false"/>.</returns>
+		public bool TryToDateTimeOffset(out DateTimeOffset timestamp)
+		{
+			if (id.ToDateTime() is { } dt)
+			{
+				timestamp = new DateTimeOffset(dt, TimeSpan.Zero);
+				return true;
+			}
+			timestamp = default;
+			return false;
+		}
+
 		/// <summary>
 		/// Converts a <see cref="Guid"/> to its SQL Server byte order equivalent.
 		/// </summary>

--- a/src/SequentialGuid/Extensions/GuidExtensions.cs
+++ b/src/SequentialGuid/Extensions/GuidExtensions.cs
@@ -86,6 +86,10 @@ public static class GuidExtensions
 			return false;
 		}
 
+		/// <summary>Returns true if <paramref name="id"/> is a recognised sequential GUID (V7, V8, or legacy format) in either standard or SQL Server byte order.</summary>
+		public bool IsSequentialGuid() =>
+			SequentialGuidByteOrder.TryDetect(id, out _);
+
 		/// <summary>
 		/// Converts a <see cref="Guid"/> to its SQL Server byte order equivalent.
 		/// </summary>

--- a/src/SequentialGuid/Extensions/GuidExtensions.cs
+++ b/src/SequentialGuid/Extensions/GuidExtensions.cs
@@ -86,7 +86,7 @@ public static class GuidExtensions
 			return false;
 		}
 
-		/// <summary>Returns true if this GUID is a recognised sequential GUID (V7, V8, or legacy format) in either standard or SQL Server byte order.</summary>
+		/// <summary>Returns true if this GUID is a recognized sequential GUID (V7, V8, or legacy format) in either standard or SQL Server byte order.</summary>
 		public bool IsSequentialGuid() =>
 			SequentialGuidByteOrder.TryDetect(id, out _);
 

--- a/src/SequentialGuid/GuidNameBased.cs
+++ b/src/SequentialGuid/GuidNameBased.cs
@@ -34,7 +34,7 @@ internal static class GuidNameBased
 		return new(digest.SwapByteOrder());
 #elif NET6_0_OR_GREATER
 		const int StackThreshold = 256;
-		var totalLen = 16 + name.Length;
+		var totalLen = checked(16 + name.Length);
 
 		Span<byte> stackBuf = stackalloc byte[StackThreshold];
 		byte[]? rented = null;

--- a/src/SequentialGuid/GuidNameBased.cs
+++ b/src/SequentialGuid/GuidNameBased.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 #endif
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using SequentialGuid.Extensions;
 
@@ -17,6 +18,7 @@ internal static class GuidNameBased
 		internal static readonly Guid X500 = new("6ba7b814-9dad-11d1-80b4-00c04fd430c8");
 	}
 
+	[SkipLocalsInit]
 	[SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms",
 		Justification = "RFC 9562 §A.4 mandates SHA-1 for UUIDv5 name-based identifiers; this is a specification requirement, not a security primitive.")]
 	internal static Guid Create(Guid namespaceId, byte[] name, HashAlgorithmName algorithmName, byte version)

--- a/src/SequentialGuid/GuidNameBased.cs
+++ b/src/SequentialGuid/GuidNameBased.cs
@@ -1,3 +1,7 @@
+#if NET6_0_OR_GREATER
+using System.Buffers;
+#endif
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using SequentialGuid.Extensions;
 
@@ -13,6 +17,8 @@ internal static class GuidNameBased
 		internal static readonly Guid X500 = new("6ba7b814-9dad-11d1-80b4-00c04fd430c8");
 	}
 
+	[SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms",
+		Justification = "RFC 9562 §A.4 mandates SHA-1 for UUIDv5 name-based identifiers; this is a specification requirement, not a security primitive.")]
 	internal static Guid Create(Guid namespaceId, byte[] name, HashAlgorithmName algorithmName, byte version)
 	{
 #if NETFRAMEWORK
@@ -24,30 +30,51 @@ internal static class GuidNameBased
 		digest.SetRfc9562Version(version);
 		digest.SetRfc9562Variant();
 		return new(digest.SwapByteOrder());
+#elif NET6_0_OR_GREATER
+		const int StackThreshold = 256;
+		var totalLen = 16 + name.Length;
+
+		Span<byte> stackBuf = stackalloc byte[StackThreshold];
+		byte[]? rented = null;
+		var input = totalLen <= StackThreshold
+			? stackBuf[..totalLen]
+			: (rented = ArrayPool<byte>.Shared.Rent(totalLen)).AsSpan(0, totalLen);
+		try
+		{
+#if NET8_0_OR_GREATER
+			namespaceId.TryWriteBytes(input[..16], bigEndian: true, out _);
 #else
-		using var hash = IncrementalHash.CreateHash(algorithmName);
-		hash.AppendData(namespaceId
-#if NETSTANDARD
-			.ToByteArray().SwapByteOrder()
-#else
-			.ToByteArray(true)
+			// NET6/7: TryWriteBytes(span, bigEndian) doesn't exist; write native order then swap in-place
+			namespaceId.TryWriteBytes(input[..16]);
+			input[..16].SwapGuidBytesInPlace();
 #endif
-		);
-		hash.AppendData(name);
-#if NET6_0_OR_GREATER
-		// SHA-256 is the widest digest we use (32 bytes); SHA-1 fills the first 20.
-		Span<byte> digest = stackalloc byte[32];
-		hash.TryGetHashAndReset(digest, out _);
-		var head = digest[..16];
-		head.SetRfc9562Version(version);
-		head.SetRfc9562Variant();
-		return new(head, bigEndian: true);
+			name.AsSpan().CopyTo(input.Slice(16, name.Length));
+
+			// SHA-256 is the widest digest we use (32 bytes); SHA-1 fills the first 20.
+			Span<byte> digest = stackalloc byte[32];
+			if (algorithmName == HashAlgorithmName.SHA1)
+				SHA1.HashData(input, digest);
+			else
+				SHA256.HashData(input, digest);
+
+			var head = digest[..16];
+			head.SetRfc9562Version(version);
+			head.SetRfc9562Variant();
+			return new(head, bigEndian: true);
+		}
+		finally
+		{
+			if (rented is not null) ArrayPool<byte>.Shared.Return(rented);
+		}
 #else
+		// netstandard2.0 — TryGetHashAndReset(Span<byte>, out int) is .NET 5+ / netstandard 2.1+
+		using var hash = IncrementalHash.CreateHash(algorithmName);
+		hash.AppendData(namespaceId.ToByteArray().SwapByteOrder());
+		hash.AppendData(name);
 		var digest = hash.GetHashAndReset();
 		digest.SetRfc9562Version(version);
 		digest.SetRfc9562Variant();
 		return new(digest.SwapByteOrder());
-#endif
 #endif
 	}
 }

--- a/src/SequentialGuid/GuidV4.cs
+++ b/src/SequentialGuid/GuidV4.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using SequentialGuid.Extensions;
 
@@ -18,6 +19,7 @@ public static class GuidV4
 	/// Creates a new UUID version 4 using a cryptographically strong random number generator.
 	/// </summary>
 	/// <returns>A new random version 4 <see cref="Guid"/>.</returns>
+	[SkipLocalsInit]
 	public static Guid NewGuid()
 	{
 		// Build 16 bytes in network (big-endian) byte order per RFC 9562 Section 5.4

--- a/src/SequentialGuid/GuidV7.cs
+++ b/src/SequentialGuid/GuidV7.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using SequentialGuid.Extensions;
 
@@ -125,6 +126,7 @@ public static class GuidV7
 	/// <exception cref="ArgumentOutOfRangeException">
 	/// Thrown when <paramref name="unixMilliseconds"/> is negative or exceeds the 48-bit maximum.
 	/// </exception>
+	[SkipLocalsInit]
 	public static Guid NewGuid(long unixMilliseconds)
 	{
 		if (unixMilliseconds is < 0 or > 0x0000_FFFF_FFFF_FFFF)

--- a/src/SequentialGuid/GuidV7.cs
+++ b/src/SequentialGuid/GuidV7.cs
@@ -89,7 +89,7 @@ public static class GuidV7
 	/// </summary>
 	/// <returns>A new time-ordered version 7 <see cref="Guid"/>.</returns>
 	public static Guid NewGuid() =>
-		NewGuid(DateTimeOffset.UtcNow);
+		NewGuid(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 
 	/// <summary>
 	/// Creates a new UUID version 7 from a <see cref="DateTimeOffset"/> timestamp.

--- a/src/SequentialGuid/GuidV8Time.cs
+++ b/src/SequentialGuid/GuidV8Time.cs
@@ -1,6 +1,7 @@
 #if !NET6_0_OR_GREATER
 using System.Diagnostics;
 #endif
+using System.Runtime.CompilerServices;
 using System.Security;
 using System.Security.Cryptography;
 using System.Text;
@@ -155,6 +156,7 @@ public static class GuidV8Time
 	public static Guid NewGuid(DateTimeOffset timestamp) =>
 		NewGuid(timestamp.UtcDateTime);
 
+	[SkipLocalsInit]
 	internal static Guid NewGuid(long timestamp)
 	{
 		// only use low order 22 bits

--- a/src/SequentialGuid/README.md
+++ b/src/SequentialGuid/README.md
@@ -29,7 +29,7 @@ SequentialGuid is a zero-dependency .NET library that produces [RFC 9562](https:
 - **RFC 9562 compliant** — correct version nibble and variant bits on every UUID, every time
 - **Monotonically increasing** — `GuidV7` and `GuidV8Time` both use a process-global `Interlocked.Increment` counter so IDs generated on the same timestamp are still strictly ordered, even under heavy concurrency
 - **Zero dependencies** — the core package references nothing outside the BCL
-- **Zero allocations on modern .NET** — `stackalloc`, `Span<T>`, and `[SkipLocalsInit]` eliminate heap allocations on the hot path (.NET 8+)
+- **Zero allocations on modern .NET** — `stackalloc`, `Span<T>`, and `[SkipLocalsInit]` eliminate heap allocations on **every** generation path (.NET 6+), including the deterministic v5/v8 name-based generators
 - **Broad platform support** — targets **.NET 10 / 9 / 8**, **.NET Framework 4.6.2**, and **.NET Standard 2.0**, with explicit `browser` platform support and Native AOT compatibility for Blazor WebAssembly
 - **Native AOT compatible** — declares `IsAotCompatible=true` and is verified end-to-end with a published AOT smoke test in CI
 - **Round-trip timestamp extraction** — call `.ToDateTime()` on any `Guid` (V7, V8, or legacy) to recover the embedded UTC timestamp — works on `SqlGuid` too
@@ -109,6 +109,25 @@ var id = GuidV8Name.Create(GuidV8Name.Namespaces.Url, "https://example.com");
 ```csharp
 DateTime? created = id.ToDateTime();
 // Works on GuidV7, GuidV8Time, legacy SequentialGuid, and even SqlGuid values
+```
+
+### Helpers for common timestamp & predicate scenarios
+
+```csharp
+// Try-pattern variant — useful when you want to branch without nullable handling
+if (id.TryToDateTime(out var created))
+{
+    Console.WriteLine($"Created at {created:O}");
+}
+
+// DateTimeOffset variant — explicit UTC offset
+DateTimeOffset? created = id.ToDateTimeOffset();
+
+// Predicate — "is this a recognised sequential GUID at all?"
+bool isOurs = someGuid.IsSequentialGuid();
+
+// RFC 9562 §5.10 max UUID constant — useful for range-scan upper bounds
+Guid upper = Guid.MaxValue;
 ```
 
 ### Convert between Guid and SqlGuid byte order

--- a/src/SequentialGuid/README.md
+++ b/src/SequentialGuid/README.md
@@ -29,7 +29,7 @@ SequentialGuid is a zero-dependency .NET library that produces [RFC 9562](https:
 - **RFC 9562 compliant** — correct version nibble and variant bits on every UUID, every time
 - **Monotonically increasing** — `GuidV7` and `GuidV8Time` both use a process-global `Interlocked.Increment` counter so IDs generated on the same timestamp are still strictly ordered, even under heavy concurrency
 - **Zero dependencies** — the core package references nothing outside the BCL
-- **Zero allocations on modern .NET** — `stackalloc`, `Span<T>`, and `[SkipLocalsInit]` eliminate heap allocations on **every** generation path on the package's modern TFMs (.NET 8+), including the deterministic v5/v8 name-based generators
+- **Zero allocations on modern .NET** — `stackalloc`, `Span<T>`, and `[SkipLocalsInit]` eliminate heap allocations on **every** generation path on the package's **.NET 10 / 9 / 8** targets, including the deterministic v5/v8 name-based generators
 - **Broad platform support** — targets **.NET 10 / 9 / 8**, **.NET Framework 4.6.2**, and **.NET Standard 2.0**, with explicit `browser` platform support and Native AOT compatibility for Blazor WebAssembly
 - **Native AOT compatible** — declares `IsAotCompatible=true` and is verified end-to-end with a published AOT smoke test in CI
 - **Round-trip timestamp extraction** — call `.ToDateTime()` on any `Guid` (V7, V8, or legacy) to recover the embedded UTC timestamp — works on `SqlGuid` too

--- a/src/SequentialGuid/README.md
+++ b/src/SequentialGuid/README.md
@@ -29,7 +29,7 @@ SequentialGuid is a zero-dependency .NET library that produces [RFC 9562](https:
 - **RFC 9562 compliant** — correct version nibble and variant bits on every UUID, every time
 - **Monotonically increasing** — `GuidV7` and `GuidV8Time` both use a process-global `Interlocked.Increment` counter so IDs generated on the same timestamp are still strictly ordered, even under heavy concurrency
 - **Zero dependencies** — the core package references nothing outside the BCL
-- **Zero allocations on modern .NET** — `stackalloc`, `Span<T>`, and `[SkipLocalsInit]` eliminate heap allocations on **every** generation path (.NET 6+), including the deterministic v5/v8 name-based generators
+- **Zero allocations on modern .NET** — `stackalloc`, `Span<T>`, and `[SkipLocalsInit]` eliminate heap allocations on **every** generation path on the package's modern TFMs (.NET 8+), including the deterministic v5/v8 name-based generators
 - **Broad platform support** — targets **.NET 10 / 9 / 8**, **.NET Framework 4.6.2**, and **.NET Standard 2.0**, with explicit `browser` platform support and Native AOT compatibility for Blazor WebAssembly
 - **Native AOT compatible** — declares `IsAotCompatible=true` and is verified end-to-end with a published AOT smoke test in CI
 - **Round-trip timestamp extraction** — call `.ToDateTime()` on any `Guid` (V7, V8, or legacy) to recover the embedded UTC timestamp — works on `SqlGuid` too
@@ -121,7 +121,7 @@ if (id.TryToDateTime(out var created))
 }
 
 // DateTimeOffset variant — explicit UTC offset
-DateTimeOffset? created = id.ToDateTimeOffset();
+DateTimeOffset? createdOffset = id.ToDateTimeOffset();
 
 // Predicate — "is this a recognised sequential GUID at all?"
 bool isOurs = someGuid.IsSequentialGuid();

--- a/test/SequentialGuid.AotSmokeTest/Program.cs
+++ b/test/SequentialGuid.AotSmokeTest/Program.cs
@@ -75,6 +75,18 @@ var json = JsonSerializer.Serialize(sg, typeInfo);
 var roundTripped = JsonSerializer.Deserialize(json, typeInfo);
 Check("JSON roundtrip preserves Value", roundTripped.Value == sg.Value);
 
+// v6.1 ergonomic extensions
+Check("Guid.MaxValue non-empty", Guid.MaxValue != Guid.Empty);
+
+Check("v7 TryToDateTime true", v7.TryToDateTime(out var v7Dt) && v7Dt > DateTime.MinValue);
+Check("v4 TryToDateTime false", !v4.TryToDateTime(out _));
+
+Check("v7 ToDateTimeOffset Utc", v7.ToDateTimeOffset() is { Offset.Ticks: 0 });
+Check("v4 ToDateTimeOffset null", v4.ToDateTimeOffset() is null);
+
+Check("v7 IsSequentialGuid true", v7.IsSequentialGuid());
+Check("v4 IsSequentialGuid false", !v4.IsSequentialGuid());
+
 if (failures.Count == 0)
 {
 	Console.WriteLine("AOT smoke test: PASS");

--- a/test/SequentialGuid.Tests/GuidExtensionsTests.cs
+++ b/test/SequentialGuid.Tests/GuidExtensionsTests.cs
@@ -1,3 +1,5 @@
+using SequentialGuid;
+
 namespace SequentialGuid.Tests;
 
 public sealed class GuidExtensionsTests
@@ -12,5 +14,35 @@ public sealed class GuidExtensionsTests
 	void MaxValueIsNotEmpty()
 	{
 		Guid.MaxValue.ShouldNotBe(Guid.Empty);
+	}
+
+	[Fact]
+	void TryToDateTimeReturnsTrueForSequentialGuid()
+	{
+		// Arrange
+		var v7 = GuidV7.NewGuid();
+		// Act
+		var success = v7.TryToDateTime(out var timestamp);
+		// Assert
+		success.ShouldBeTrue();
+		timestamp.ShouldBe(v7.ToDateTime()!.Value);
+	}
+
+	[Fact]
+	void TryToDateTimeReturnsFalseForRandomV4()
+	{
+		// RFC 9562 §A.4 v4 vector — known not a sequential guid
+		var v4 = new Guid("919108f7-52d1-4320-9bac-f847db4148a8");
+		var success = v4.TryToDateTime(out var timestamp);
+		success.ShouldBeFalse();
+		timestamp.ShouldBe(default(DateTime));
+	}
+
+	[Fact]
+	void TryToDateTimeReturnsFalseForEmpty()
+	{
+		var success = Guid.Empty.TryToDateTime(out var timestamp);
+		success.ShouldBeFalse();
+		timestamp.ShouldBe(default(DateTime));
 	}
 }

--- a/test/SequentialGuid.Tests/GuidExtensionsTests.cs
+++ b/test/SequentialGuid.Tests/GuidExtensionsTests.cs
@@ -82,4 +82,47 @@ public sealed class GuidExtensionsTests
 		success.ShouldBeFalse();
 		dto.ShouldBe(default(DateTimeOffset));
 	}
+
+	[Fact]
+	void IsSequentialGuidTrueForV7()
+	{
+		GuidV7.NewGuid().IsSequentialGuid().ShouldBeTrue();
+	}
+
+	[Fact]
+	void IsSequentialGuidTrueForV8Time()
+	{
+		GuidV8Time.NewGuid().IsSequentialGuid().ShouldBeTrue();
+	}
+
+	[Fact]
+	void IsSequentialGuidTrueForLegacy()
+	{
+		new Guid("08de7bf5-381d-cc8b-f24c-56e3580439dd").IsSequentialGuid().ShouldBeTrue();
+	}
+
+	[Fact]
+	void IsSequentialGuidTrueForSqlOrderedV7()
+	{
+		GuidV7.NewSqlGuid().IsSequentialGuid().ShouldBeTrue();
+	}
+
+	[Fact]
+	void IsSequentialGuidFalseForRandomV4()
+	{
+		// RFC 9562 §A.4 v4 vector
+		new Guid("919108f7-52d1-4320-9bac-f847db4148a8").IsSequentialGuid().ShouldBeFalse();
+	}
+
+	[Fact]
+	void IsSequentialGuidFalseForEmpty()
+	{
+		Guid.Empty.IsSequentialGuid().ShouldBeFalse();
+	}
+
+	[Fact]
+	void IsSequentialGuidFalseForMaxValue()
+	{
+		Guid.MaxValue.IsSequentialGuid().ShouldBeFalse();
+	}
 }

--- a/test/SequentialGuid.Tests/GuidExtensionsTests.cs
+++ b/test/SequentialGuid.Tests/GuidExtensionsTests.cs
@@ -45,4 +45,41 @@ public sealed class GuidExtensionsTests
 		success.ShouldBeFalse();
 		timestamp.ShouldBe(default(DateTime));
 	}
+
+	[Fact]
+	void ToDateTimeOffsetReturnsUtcOffsetForSequentialGuid()
+	{
+		// Arrange
+		var v7 = GuidV7.NewGuid();
+		// Act
+		var dto = v7.ToDateTimeOffset();
+		// Assert
+		dto.ShouldNotBeNull();
+		dto.Value.Offset.ShouldBe(TimeSpan.Zero);
+	}
+
+	[Fact]
+	void ToDateTimeOffsetReturnsNullForRandomV4()
+	{
+		var v4 = new Guid("919108f7-52d1-4320-9bac-f847db4148a8");
+		v4.ToDateTimeOffset().ShouldBeNull();
+	}
+
+	[Fact]
+	void TryToDateTimeOffsetReturnsTrueForSequentialGuid()
+	{
+		var v7 = GuidV7.NewGuid();
+		var success = v7.TryToDateTimeOffset(out var dto);
+		success.ShouldBeTrue();
+		dto.Offset.ShouldBe(TimeSpan.Zero);
+	}
+
+	[Fact]
+	void TryToDateTimeOffsetReturnsFalseForRandomV4()
+	{
+		var v4 = new Guid("919108f7-52d1-4320-9bac-f847db4148a8");
+		var success = v4.TryToDateTimeOffset(out var dto);
+		success.ShouldBeFalse();
+		dto.ShouldBe(default(DateTimeOffset));
+	}
 }

--- a/test/SequentialGuid.Tests/GuidExtensionsTests.cs
+++ b/test/SequentialGuid.Tests/GuidExtensionsTests.cs
@@ -1,0 +1,16 @@
+namespace SequentialGuid.Tests;
+
+public sealed class GuidExtensionsTests
+{
+	[Fact]
+	void MaxValueIsAllBitsSet()
+	{
+		Guid.MaxValue.ShouldBe(new("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+	}
+
+	[Fact]
+	void MaxValueIsNotEmpty()
+	{
+		Guid.MaxValue.ShouldNotBe(Guid.Empty);
+	}
+}


### PR DESCRIPTION
## Summary

  SemVer minor release. **No breaking changes.**

  ### Perf
  - 🚀 **`GuidV5.Create(byte[])` and `GuidV8Name.Create(byte[])` drop from ~176 B/call to 0 B/call on .NET 6+.** Rewrites `GuidNameBased.Create` to use one-shot
  `SHA1.HashData` / `SHA256.HashData` (both .NET 5+) with a `stackalloc`/`ArrayPool` concat buffer.
  - ⚡ **`[SkipLocalsInit]` applied to `GuidV4`, `GuidV7`, `GuidV8Time`, `GuidNameBased` generator methods** — skips redundant JIT zero-init of `stackalloc`
  buffers (every byte is explicitly written).
  - 🧹 **`GuidV7.NewGuid()` no-arg** inlines `ToUnixTimeMilliseconds` extraction, saves one `DateTimeOffset` struct copy.

  ### Ergonomic features (additive, purely)
  - ✨ **`Guid.MaxValue`** — RFC 9562 §5.10 max UUID constant. Backed by a `private static readonly` cache.
  - ✨ **`Guid.TryToDateTime(out DateTime)`** — BCL-style Try-pattern variant of the existing `ToDateTime()`.
  - ✨ **`Guid.ToDateTimeOffset()` + `Guid.TryToDateTimeOffset(out DateTimeOffset)`** — explicit-UTC variants.
  - ✨ **`Guid.IsSequentialGuid()`** — public predicate delegating to internal `SequentialGuidByteOrder.TryDetect`.

  ## Benchmark deltas (BenchmarkDotNet on .NET 10)

  | Method | Before (v6.0) | After (v6.1) |
  |---|---|---|
  | `GuidV5.Create(byte[])` 20-char name | 176 B | **–** |
  | `GuidV5.Create(byte[])` 71-char name | 176 B | **–** |
  | `GuidV8Name.Create(byte[])` 20-char name | 176 B | **–** |
  | `GuidV8Name.Create(byte[])` 71-char name | 176 B | **–** |
  | `GuidV5.Create(string)` | — | 48–96 B (UTF-8 buffer, caller-controlled, unchanged) |
  | `Guid.NewGuid` baseline | – | – |
  | `GuidV4`, `GuidV7`, `GuidV7.NewSqlGuid`, `GuidV8Time`, `GuidV8Time.NewSqlGuid` | – | – (unchanged) |

  **Every generation path is now 0 B allocated on .NET 6+** (for the `byte[]` overloads of v5/v8 name-based).

  ## Test plan

  - [x] `dotnet build` clean on all 5 production TFMs (`net10.0`, `net9.0`, `net8.0`, `net462`, `netstandard2.0`); 0 warnings under `TreatWarningsAsErrors=true`
  - [x] `dotnet test` — all tests pass (~25,067 total, +64 new from `GuidExtensionsTests` across 4 test TFMs)
  - [x] RFC 9562 §A.4 SHA-1 vector (`2ed6657d-e927-568b-95e1-2665a8aea6a2` for `(Dns, "www.example.com")`) still passes byte-for-byte
  - [x] `NameBenchmarks` shows `Allocated: –` for both `(byte[])` overloads at both name lengths
  - [x] AOT smoke test exercises the four new extensions (JIT pass verified locally; full AOT publish runs in CI)
  - [ ] CI green on `windows-latest` with .NET 8/9/10 + AOT publish step

  ## Implementation notes

  - The `[SuppressMessage("Security", "CA5350")]` on `GuidNameBased.Create` is required because `SHA1.HashData` is flagged by CA5350 (SHA-1 is weak for crypto
  purposes). RFC 9562 §A.4 mandates SHA-1 for UUIDv5 — this is interop with the spec, not a security boundary. The suppression is scoped to the single method with
  a Justification.
  - The conditional `Span<byte>` lifetime pattern in `GuidNameBased.Create` (`stackalloc byte[256]` declared at outer scope, conditional assignment to slice or
  `ArrayPool`-rented array, `try/finally` for release) is sound under C# scope-based span safety rules.
  - The static `Guid.MaxValue` extension lives inside the existing `extension(Guid id)` block (instance-receiver block hosting a `static` member). Separating into
  its own `extension(Guid)` block triggers CA1708 (members differing only by case) — consolidation resolves it.

  ## Suggested follow-ups (out of scope here)

  - Add `IsSequentialGuidTrueForSqlOrderedV8` for symmetry with the v7 SQL-order test.
  - A `Span<char>` / UTF-8 overload of `GuidV5.Create` / `GuidV8Name.Create` to close out the last allocation in the `string` path.
  - Small `ExtensionBenchmarks.cs` to keep `IsSequentialGuid` / `TryToDateTime` perf honest as the detector grows.

  ## References

  - Spec: `docs/superpowers/specs/2026-05-12-sequentialguid-v6.1-design.md`
  - Plan: `docs/superpowers/plans/2026-05-12-sequentialguid-v6.1.md`
  - v6.0 release: PR #22